### PR TITLE
#37: close DrawerLayout's on back button if open

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -3783,6 +3783,17 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             mp.reset();
             mpTitle = "";
         }
+
+        if (mDrawerLayout.isDrawerOpen(songmenu)) {
+            mDrawerLayout.closeDrawer(songmenu);
+            return;
+        }
+        if (mDrawerLayout.isDrawerOpen(optionmenu)) {
+            mDrawerLayout.closeDrawer(optionmenu);
+            return;
+        }
+
+
         String message = getResources().getString(R.string.exit);
         FullscreenActivity.whattodo = "exit";
         newFragment = PopUpAreYouSureFragment.newInstance(message);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -914,6 +914,15 @@ public class StageMode extends AppCompatActivity implements
     @Override
     public void onBackPressed() {
 
+        if (mDrawerLayout.isDrawerOpen(songmenu)) {
+            mDrawerLayout.closeDrawer(songmenu);
+            return;
+        }
+        if (mDrawerLayout.isDrawerOpen(optionmenu)) {
+            mDrawerLayout.closeDrawer(optionmenu);
+            return;
+        }
+
         String message = getResources().getString(R.string.exit);
         FullscreenActivity.whattodo = "exit";
         newFragment = PopUpAreYouSureFragment.newInstance(message);


### PR DESCRIPTION
I have fixed #37 both for Presenter and Stage mode. I do not like the redundancy but I wanted a minimal change. Extracting a super-class to share common code between the two modes would be a different story/issue. I tested and debugged my change and it works as expected to me.