### PR TITLE
Fix chordpro converter

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 class ChordProConvert {
 
     static boolean doExtract() throws IOException {
-        Log.d("chordprofix", "extract");
 
         // This is called when a ChordPro format song has been loaded.
         // This tries to extract the relevant stuff and reformat the
@@ -25,11 +24,11 @@ class ChordProConvert {
 
         // Break the temp variable into an array split by line
         // Check line endings are \n
-        Log.d("chordprofix", ""+temp);
+
         temp = fixLineBreaksAndSlashes(temp);
-        Log.d("chordprofix", "AFTER:"+temp);
+
         String[] line = temp.split("\n");
-        Log.d("chordprofix", "LINE:"+ Arrays.toString(line));
+
         int numlines = line.length;
         if (numlines < 0) {
             numlines = 1;
@@ -161,7 +160,7 @@ class ChordProConvert {
 
         // Change start and end of chorus
         while (parsedlines.contains("{start_of_chorus")) {
-            Log.d("ParsedLines", "~"+parsedlines);
+
             parsedlines = parsedlines.replace("{start_of_chorus}","[C]");
             parsedlines = parsedlines.replace("{start_of_chorus:}","[C]");
             parsedlines = parsedlines.replace("{start_of_chorus :}","[C]");
@@ -172,7 +171,7 @@ class ChordProConvert {
         }
 
         while (parsedlines.contains("{end_of_chorus")) {
-            Log.d("ParsedLines", "~"+parsedlines);
+
             parsedlines = parsedlines.replace("{end_of_chorus}","[]");
             parsedlines = parsedlines.replace("{end_of_chorus:}","[]");
             parsedlines = parsedlines.replace("{end_of_chorus :}","[]");
@@ -187,7 +186,7 @@ class ChordProConvert {
          * {eob}
          * */
         while (parsedlines.contains("{start_of_bridge")) {
-            Log.d("ParsedLines", "~"+parsedlines);
+
             parsedlines = parsedlines.replace("{start_of_bridge}","[B]");
             parsedlines = parsedlines.replace("{start_of_bridge:}","[B]");
             parsedlines = parsedlines.replace("{start_of_bridge :}","[B]");
@@ -198,7 +197,7 @@ class ChordProConvert {
         }
 
         while (parsedlines.contains("{end_of_bridge")) {
-            Log.d("ParsedLines", "~"+parsedlines);
+
             parsedlines = parsedlines.replace("{end_of_bridge}","[]");
             parsedlines = parsedlines.replace("{end_of_bridge:}","[]");
             parsedlines = parsedlines.replace("{end_of_bridge :}","[]");
@@ -229,7 +228,7 @@ class ChordProConvert {
         // Go through the lines one at a time
         // Add the fixed bit back together
         for (int x = 0; x < numlines2; x++) {
-            Log.d("LineAddSpaceIfNot","~"+line2[x]);
+
             if (line2[x].length() > 1) {
 
                 //Take the line and eliminates spaces before the first letter of symbol
@@ -296,8 +295,7 @@ class ChordProConvert {
                 + "  <link_audio></link_audio>\n"
                 + "  <link_other></link_other>\n"
                 + "</song>";
-        Log.d("ParsedLinesNoTRIM","~"+parsedlines.trim());
-        Log.d("ParsedLinesTRIM","~"+parsedlines.trim());
+
         // Save this song in the right format!
         // Makes sure all & are replaced with &amp;
         FullscreenActivity.myXML = FullscreenActivity.myXML.replace("&amp;",

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -7,29 +7,36 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 class ChordProConvert {
 
-	static boolean doExtract() throws IOException {
+    static boolean doExtract() throws IOException {
+        Log.d("chordprofix", "extract");
 
-		// This is called when a ChordPro format song has been loaded.
-		// This tries to extract the relevant stuff and reformat the
-		// <lyrics>...</lyrics>
-		String temp = FullscreenActivity.myXML;
-		StringBuilder parsedlines;
-		// Initialise all the xml tags a song should have
-		FullscreenActivity.mTitle = FullscreenActivity.songfilename;
-		LoadXML.initialiseSongTags();
+        // This is called when a ChordPro format song has been loaded.
+        // This tries to extract the relevant stuff and reformat the
+        // <lyrics>...</lyrics>
+        String temp = FullscreenActivity.myXML;
+        String parsedlines;
+        // Initialise all the xml tags a song should have
+        FullscreenActivity.mTitle = FullscreenActivity.songfilename;
+        LoadXML.initialiseSongTags();
 
-		// Break the temp variable into an array split by line
-		// Check line endings are \n
-		temp = fixLineBreaksAndSlashes(temp);
-
-		String[] line = temp.split("\n");
-		int numlines = line.length;
+        // Break the temp variable into an array split by line
+        // Check line endings are \n
+        Log.d("chordprofix", ""+temp);
+        temp = fixLineBreaksAndSlashes(temp);
+        Log.d("chordprofix", "AFTER:"+temp);
+        String[] line = temp.split("\n");
+        Log.d("chordprofix", "LINE:"+ Arrays.toString(line));
+        int numlines = line.length;
+        if (numlines < 0) {
+            numlines = 1;
+        }
 
         String temptitle = "";
-		String tempsubtitle;
+        String tempsubtitle;
         String tempccli = "";
         String tempauthor = "";
         String tempcopyright = "";
@@ -37,25 +44,27 @@ class ChordProConvert {
         String temptimesig = "";
         String temptempo = "";
 
-		// Go through individual lines and fix simple stuff
-		for (int x = 0; x < numlines; x++) {
-			// Get rid of any extra whitespace
-			line[x] = line[x].trim();
-			
-			// Make tag lines common
-			line[x] = makeTagsCommon(line[x]);
+        // Go through individual lines and fix simple stuff
+        for (int x = 0; x < numlines; x++) {
+            // Get rid of any extra whitespace
+            Log.d("LineTrimBefore","~"+line[x]);
+            line[x] = line[x].trim();
+            Log.d("LineTrimAfter","~"+line[x]);
+            // Make tag lines common
+            line[x] = makeTagsCommon(line[x]);
 
-			// Remove directive lines we don't need
+            // Remove directive lines we don't need
             line[x] = removeObsolete(line[x]);
 
-			
-			// Extract the title
-			if (line[x].contains("{title:")) {
-			    temptitle = removeTags(line[x],"{title:");
-				line[x] = "";
-			}
 
-			// Extract the author
+
+            // Extract the title
+            if (line[x].contains("{title:")) {
+                temptitle = removeTags(line[x],"{title:");
+                line[x] = "";
+            }
+
+            // Extract the author
             if (line[x].contains("{artist:")) {
                 tempauthor =  removeTags(line[x],"{artist:");
                 line[x] = "";
@@ -67,23 +76,23 @@ class ChordProConvert {
                 line[x] = "";
             }
 
-			// Extract the subtitles
-			if (line[x].contains("{subtitle:")) {
-				tempsubtitle =  removeTags(line[x],"{subtitle:");
+            // Extract the subtitles
+            if (line[x].contains("{subtitle:")) {
+                tempsubtitle =  removeTags(line[x],"{subtitle:");
                 if (tempauthor.equals("")) {
                     tempauthor = tempsubtitle;
                 }
                 if (tempcopyright.equals("")) {
                     tempcopyright = tempsubtitle;
                 }
-				line[x] = ";" + tempsubtitle;
-			}
+                line[x] = ";" + tempsubtitle;
+            }
 
-			// Extract the ccli (not really a chordpro tag, but works for songselect and worship together
-			if (line[x].contains("{ccli:")) {
-				tempccli =  removeTags(line[x],"{ccli::");
-				line[x] = "";
-			}
+            // Extract the ccli (not really a chordpro tag, but works for songselect and worship together
+            if (line[x].contains("{ccli:")) {
+                tempccli =  removeTags(line[x],"{ccli::");
+                line[x] = "";
+            }
 
             // Extract the key
             if (line[x].contains("{key:")) {
@@ -104,123 +113,181 @@ class ChordProConvert {
             }
 
             // Change lines that start with # into comment lines
-			if (line[x].startsWith("#")) {
-				line[x] = line[x].replaceFirst("#", ";");
-			}
-			
-			// Change comment lines
-			if (line[x].contains("{comments:")) {
-				line[x] = ";" +  removeTags(line[x],"{comments:");
-			}
+            if (line[x].startsWith("#")) {
+                line[x] = line[x].replaceFirst("#", ";");
+            }
 
-			// Change comment lines
-			if (line[x].contains("{comment:")) {
-				line[x] = ";" +  removeTags(line[x],"{comment:");
-			}
+            // Change comment lines
+            if (line[x].contains("{comments:")) {
+                line[x] = ";" +  removeTags(line[x],"{comments:");
+            }
 
-		}
-		
-		// Go through each line and try to fix chord lines
-		for (int x = 0; x < numlines; x++) {
-		    line[x] = extractChordLines(line[x]);
-		}
+            // Change comment lines
+            if (line[x].contains("{comment:")) {
+                line[x] = ";" +  removeTags(line[x],"{comment:");
+            }
 
-		// Join the individual lines back up
-		parsedlines = new StringBuilder();
-		for (int x = 0; x < numlines; x++) {
-			// Try to guess tags used
+        }
+
+        // Go through each line and try to fix chord lines
+        for (int x = 0; x < numlines; x++) {
+            line[x] = extractChordLines(line[x]);
+        }
+
+        // Join the individual lines back up
+        parsedlines = "";
+        for (int x = 0; x < numlines; x++) {
+            // Try to guess tags used
             line[x] = guessTags(line[x]);
-			parsedlines.append(line[x]).append("\n");
-		}
 
-		// Remove start and end of tabs
-		while (parsedlines.toString().contains("{start_of_tab") && parsedlines.toString().contains("{end_of_tab")) {
-			int startoftabpos;
-			int endoftabpos;
-			startoftabpos = parsedlines.indexOf("{start_of_tab");
-			endoftabpos = parsedlines.indexOf("{end_of_tab") + 12;
-			
-			if (endoftabpos > 13 && startoftabpos > -1 && endoftabpos > startoftabpos) {
-				String startbit = parsedlines.substring(0, startoftabpos);
-				String endbit = parsedlines.substring(endoftabpos);
-				parsedlines = new StringBuilder(startbit + endbit);
-			}
-		}
-		
-		// Change start and end of chorus
-		while (parsedlines.toString().contains("{start_of_chorus")) {
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{start_of_chorus}", "[C]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{start_of_chorus:}", "[C]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{start_of_chorus :}", "[C]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{start_of_chorus", "[C]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace(":", ""));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("}", ""));
-		}
+            //Added to complete guess tags operation
+            line[x] = fixHeadings(line[x]);
+            parsedlines = parsedlines + line[x] + "\n";
+        }
 
-		while (parsedlines.toString().contains("{end_of_chorus")) {
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{end_of_chorus}", "[]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{end_of_chorus:}", "[]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{end_of_chorus :}", "[]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("{end_of_chorus", "[]"));
-			parsedlines = new StringBuilder(parsedlines.toString().replace(":", ""));
-			parsedlines = new StringBuilder(parsedlines.toString().replace("}", ""));
-		}
+        // Remove start and end of tabs
+        while (parsedlines.contains("{start_of_tab") && parsedlines.contains("{end_of_tab")) {
+            int startoftabpos;
+            int endoftabpos;
+            startoftabpos = parsedlines.indexOf("{start_of_tab");
+            endoftabpos = parsedlines.indexOf("{end_of_tab") + 12;
 
-		// Get rid of double line breaks
-		while (parsedlines.toString().contains("\n\n\n")) {
-			parsedlines = new StringBuilder(parsedlines.toString().replace("\n\n\n", "\n\n"));
-		}
+            if (endoftabpos > 13 && startoftabpos > -1 && endoftabpos > startoftabpos) {
+                String startbit = parsedlines.substring(0, startoftabpos);
+                String endbit = parsedlines.substring(endoftabpos);
+                parsedlines = startbit + endbit;
+            }
+        }
 
-		while (parsedlines.toString().contains(";\n\n;")) {
-			parsedlines = new StringBuilder(parsedlines.toString().replace(";\n\n;", ";\n"));
-		}
+        // Change start and end of chorus
+        while (parsedlines.contains("{start_of_chorus")) {
+            Log.d("ParsedLines", "~"+parsedlines);
+            parsedlines = parsedlines.replace("{start_of_chorus}","[C]");
+            parsedlines = parsedlines.replace("{start_of_chorus:}","[C]");
+            parsedlines = parsedlines.replace("{start_of_chorus :}","[C]");
+            parsedlines = parsedlines.replace("{start_of_chorus","[C]");
 
-		// Ok, go back through the parsed lines and add spaces to the beginning
-		// of lines that aren't comments, chords or tags
-		String[] line2 = parsedlines.toString().split("\n");
-		int numlines2 = line2.length;
+            parsedlines = parsedlines.replace(":","");
+            parsedlines = parsedlines.replace("}","");
+        }
+
+        while (parsedlines.contains("{end_of_chorus")) {
+            Log.d("ParsedLines", "~"+parsedlines);
+            parsedlines = parsedlines.replace("{end_of_chorus}","[]");
+            parsedlines = parsedlines.replace("{end_of_chorus:}","[]");
+            parsedlines = parsedlines.replace("{end_of_chorus :}","[]");
+            parsedlines = parsedlines.replace("{end_of_chorus","[]");
+            parsedlines = parsedlines.replace(":","");
+            parsedlines = parsedlines.replace("}","");
+        }
+        /*Added to support the parsing of bridge in ChordPro Format
+         * {start_of_bridge}
+         * {end_of_bridge}
+         * {sob}
+         * {eob}
+         * */
+        while (parsedlines.contains("{start_of_bridge")) {
+            Log.d("ParsedLines", "~"+parsedlines);
+            parsedlines = parsedlines.replace("{start_of_bridge}","[B]");
+            parsedlines = parsedlines.replace("{start_of_bridge:}","[B]");
+            parsedlines = parsedlines.replace("{start_of_bridge :}","[B]");
+            parsedlines = parsedlines.replace("{start_of_bridge","[B]");
+
+            parsedlines = parsedlines.replace(":","");
+            parsedlines = parsedlines.replace("}","");
+        }
+
+        while (parsedlines.contains("{end_of_bridge")) {
+            Log.d("ParsedLines", "~"+parsedlines);
+            parsedlines = parsedlines.replace("{end_of_bridge}","[]");
+            parsedlines = parsedlines.replace("{end_of_bridge:}","[]");
+            parsedlines = parsedlines.replace("{end_of_bridge :}","[]");
+            parsedlines = parsedlines.replace("{end_of_bridge","[]");
+            parsedlines = parsedlines.replace(":","");
+            parsedlines = parsedlines.replace("}","");
+        }
+
+        // Get rid of double line breaks
+        while (parsedlines.contains("\n\n\n")) {
+            parsedlines = parsedlines.replace("\n\n\n","\n\n");
+        }
+
+        while (parsedlines.contains(";\n\n;")) {
+            parsedlines = parsedlines.replace(";\n\n;",";\n");
+        }
+
+        // Ok, go back through the parsed lines and add spaces to the beginning
+        // of lines that aren't comments, chords or tags
+        String[] line2 = parsedlines.split("\n");
+        int numlines2 = line2.length;
+        if (numlines2 < 0) {
+            numlines2 = 1;
+        }
         // Reset the parsed lines
-		parsedlines = new StringBuilder();
+        parsedlines = "";
 
-		// Go through the lines one at a time
-		// Add the fixed bit back together
-		for (int x = 0; x < numlines2; x++) {
-			if (line2[x].length() > 1) {
-				if (line2[x].indexOf("[") != 0 && line2[x].indexOf(";") != 0
-						&& line2[x].indexOf(".") != 0) {
-					line2[x] = " " + line2[x];
-				}
-			}
-			parsedlines.append(line2[x]).append("\n");
-		}
+        // Go through the lines one at a time
+        // Add the fixed bit back together
+        for (int x = 0; x < numlines2; x++) {
+            Log.d("LineAddSpaceIfNot","~"+line2[x]);
+            if (line2[x].length() > 1) {
 
-		FullscreenActivity.myXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                //Take the line and eliminates spaces before the first letter of symbol
+                //to avoid taking chorus or bridge tags as lyrics
+
+
+                String lineAux =line2[x].trim();
+                /*Also could change the 0 in the if to index 1*/
+                if (lineAux.indexOf("[") != 0 && lineAux.indexOf(";") != 0
+                        && lineAux.indexOf(".") != 0 ) {
+                    /*the line contains lyrics*/
+
+                    line2[x] = " " + line2[x];
+
+
+                }
+
+
+                else{
+                    //Keep the line without spaces before a letter of symbol
+                    line2[x] = lineAux;
+
+                }
+
+            }
+            parsedlines = parsedlines + line2[x] + "\n";
+
+        }
+
+
+
+        FullscreenActivity.myXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 + "<song>\n"
-				+ "  <title>" + temptitle.trim() + "</title>\n"
-				+ "  <author>" + tempauthor.trim() + "</author>\n"
-				+ "  <copyright>" + tempcopyright.trim() + "</copyright>\n"
-				+ "  <presentation></presentation>\n"
-				+ "  <hymn_number></hymn_number>\n"
-				+ "  <capo print=\"false\"></capo>\n"
-				+ "  <tempo>" + temptempo.trim() + "</tempo>\n"
-				+ "  <time_sig>" + temptimesig.trim() + "</time_sig>\n"
-				+ "  <duration></duration>\n"
-				+ "  <ccli>" + tempccli.trim() + "</ccli>\n"
-				+ "  <theme></theme>\n"
-				+ "  <alttheme></alttheme>\n"
-				+ "  <user1></user1>\n"
-				+ "  <user2></user2>\n"
-				+ "  <user3></user3>\n"
-				+ "  <key>" + tempkey + "</key>\n"
-				+ "  <aka></aka>\n"
-				+ "  <key_line></key_line>\n"
-				+ "  <books></books>\n"
-				+ "  <midi></midi>\n"
-				+ "  <midi_index></midi_index>\n"
-				+ "  <pitch></pitch>\n"
-				+ "  <restrictions></restrictions>\n"
-				+ "  <notes></notes>\n"
-				+ "  <lyrics>" + parsedlines.toString().trim() + "</lyrics>\n"
+                + "  <title>" + temptitle.trim() + "</title>\n"
+                + "  <author>" + tempauthor.trim() + "</author>\n"
+                + "  <copyright>" + tempcopyright.trim() + "</copyright>\n"
+                + "  <presentation></presentation>\n"
+                + "  <hymn_number></hymn_number>\n"
+                + "  <capo print=\"false\"></capo>\n"
+                + "  <tempo>" + temptempo.trim() + "</tempo>\n"
+                + "  <time_sig>" + temptimesig.trim() + "</time_sig>\n"
+                + "  <duration></duration>\n"
+                + "  <ccli>" + tempccli.trim() + "</ccli>\n"
+                + "  <theme></theme>\n"
+                + "  <alttheme></alttheme>\n"
+                + "  <user1></user1>\n"
+                + "  <user2></user2>\n"
+                + "  <user3></user3>\n"
+                + "  <key>" + tempkey + "</key>\n"
+                + "  <aka></aka>\n"
+                + "  <key_line></key_line>\n"
+                + "  <books></books>\n"
+                + "  <midi></midi>\n"
+                + "  <midi_index></midi_index>\n"
+                + "  <pitch></pitch>\n"
+                + "  <restrictions></restrictions>\n"
+                + "  <notes></notes>\n"
+                + "  <lyrics>" + parsedlines.trim() + "</lyrics>\n"
                 + "  <linked_songs></linked_songs>\n"
                 + "  <pad_file></pad_file>\n"
                 + "  <custom_chords></custom_chords>\n"
@@ -228,55 +295,56 @@ class ChordProConvert {
                 + "  <link_web></link_web>\n"
                 + "  <link_audio></link_audio>\n"
                 + "  <link_other></link_other>\n"
-				+ "</song>";
-		
-		// Save this song in the right format!
-		// Makes sure all & are replaced with &amp;
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("&amp;",
-				"&");
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("&",
-				"&amp;");
-		
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("\'","'");
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Õ","'");
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Ó","'");
-		FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Ò","'");
-		// Save the file
-		Preferences.savePreferences();
+                + "</song>";
+        Log.d("ParsedLinesNoTRIM","~"+parsedlines.trim());
+        Log.d("ParsedLinesTRIM","~"+parsedlines.trim());
+        // Save this song in the right format!
+        // Makes sure all & are replaced with &amp;
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("&amp;",
+                "&");
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("&",
+                "&amp;");
 
-		// Now write the modified song
-		FileOutputStream overWrite;
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("\'","'");
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Õ","'");
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Ó","'");
+        FullscreenActivity.myXML = FullscreenActivity.myXML.replace("Ò","'");
+        // Save the file
+        Preferences.savePreferences();
 
-		if (FullscreenActivity.whichSongFolder.equals(FullscreenActivity.mainfoldername)) {
+        // Now write the modified song
+        FileOutputStream overWrite;
+
+        if (FullscreenActivity.whichSongFolder.equals(FullscreenActivity.mainfoldername)) {
             overWrite = new FileOutputStream(FullscreenActivity.dir + "/"
                     + FullscreenActivity.songfilename, false);
         } else {
             overWrite = new FileOutputStream(FullscreenActivity.dir + "/" + FullscreenActivity.whichSongFolder + "/"
                     + FullscreenActivity.songfilename, false);
         }
-		overWrite.write(FullscreenActivity.myXML.getBytes());
-		overWrite.flush();
-		overWrite.close();
+        overWrite.write(FullscreenActivity.myXML.getBytes());
+        overWrite.flush();
+        overWrite.close();
 
-		// Change the name of the song to remove chordpro file extension 
-		// (not needed)
-		StringBuilder newSongTitle = new StringBuilder(FullscreenActivity.songfilename);
+        // Change the name of the song to remove chordpro file extension
+        // (not needed)
+        String newSongTitle = FullscreenActivity.songfilename;
 
-		// Decide if a better song title is in the file
-		if (temptitle.length() > 0) {
-			newSongTitle = new StringBuilder(temptitle);
-		}
+        // Decide if a better song title is in the file
+        if (temptitle.length() > 0) {
+            newSongTitle = temptitle;
+        }
 
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".pro", ""));
-        newSongTitle = new StringBuilder(newSongTitle.toString().replace(".PRO", ""));
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".chopro", ""));
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".chordpro", ""));
-        newSongTitle = new StringBuilder(newSongTitle.toString().replace(".CHOPRO", ""));
-        newSongTitle = new StringBuilder(newSongTitle.toString().replace(".CHORDPRO", ""));
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".cho", ""));
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".CHO", ""));
-		newSongTitle = new StringBuilder(newSongTitle.toString().replace(".txt", ""));
-        newSongTitle = new StringBuilder(newSongTitle.toString().replace(".TXT", ""));
+        newSongTitle = newSongTitle.replace(".pro", "");
+        newSongTitle = newSongTitle.replace(".PRO", "");
+        newSongTitle = newSongTitle.replace(".chopro", "");
+        newSongTitle = newSongTitle.replace(".chordpro", "");
+        newSongTitle = newSongTitle.replace(".CHOPRO", "");
+        newSongTitle = newSongTitle.replace(".CHORDPRO", "");
+        newSongTitle = newSongTitle.replace(".cho", "");
+        newSongTitle = newSongTitle.replace(".CHO", "");
+        newSongTitle = newSongTitle.replace(".txt", "");
+        newSongTitle = newSongTitle.replace(".TXT", "");
 
         File from;
         File to;
@@ -293,36 +361,36 @@ class ChordProConvert {
         }
 
         // IF THE FILENAME ALREADY EXISTS, REALLY SHOULD ASK THE USER FOR A NEW FILENAME
-		// OR append _ to the end - STILL TO DO!!!!!
-		while(to.exists()) {
-			newSongTitle.append("_");
+        // OR append _ to the end - STILL TO DO!!!!!
+        while(to.exists()) {
+            newSongTitle = newSongTitle+"_";
             if (FullscreenActivity.whichSongFolder.equals(FullscreenActivity.mainfoldername)) {
                 to = new File(FullscreenActivity.dir + "/" + newSongTitle);
             } else {
                 to = new File(FullscreenActivity.dir + "/" + FullscreenActivity.whichSongFolder + "/" + newSongTitle);
             }
-		}
-		
-		// Do the renaming
-		if(!from.renameTo(to)) {
+        }
+
+        // Do the renaming
+        if(!from.renameTo(to)) {
             Log.d("d","Couldn't rename");
         }
-		FullscreenActivity.songfilename = newSongTitle.toString();
+        FullscreenActivity.songfilename = newSongTitle;
 
-		// Load the songs
-		ListSongFiles.getAllSongFiles();
+        // Load the songs
+        ListSongFiles.getAllSongFiles();
 
-		// Get the song indexes
-		ListSongFiles.getCurrentSongIndex();
-		Preferences.savePreferences();
+        // Get the song indexes
+        ListSongFiles.getCurrentSongIndex();
+        Preferences.savePreferences();
 
         // Prepare the app to fix the song menu with the new file
         FullscreenActivity.converting = true;
 
-		return true;
-	}
+        return true;
+    }
 
-	private static String fixLineBreaksAndSlashes(String s) {
+    private static String fixLineBreaksAndSlashes(String s) {
         s = s.replace("\r\n", "\n");
         s = s.replace("\r", "\n");
         s = s.replace("\n\n\n", "\n\n");
@@ -354,9 +422,9 @@ class ChordProConvert {
         s = s.replace("{c:", "{comments:");
         s = s.replace("{c :", "{comments:");
         s = s.replace("{sot", "{start_of_tab");
-        s = s.replace("{sob", "{start_of_tab");
+        s = s.replace("{sob", "{start_of_bridge");
         s = s.replace("{eot", "{end_of_tab");
-        s = s.replace("{eob", "{end_of_tab");
+        s = s.replace("{eob", "{end_of_bridge");
         s = s.replace("{soc", "{start_of_chorus");
         s = s.replace("{eoc", "{end_of_chorus");
         s = s.replace("{comment_italic :", "{comments:");
@@ -410,7 +478,7 @@ class ChordProConvert {
     }
 
     private static String extractChordLines(String s) {
-        StringBuilder tempchordline = new StringBuilder();
+        String tempchordline = "";
         if (!s.startsWith("#") && !s.startsWith(";")) {
             // Look for [ and ] signifying a chord
             while (s.contains("[") && s.contains("]")) {
@@ -440,10 +508,10 @@ class ChordProConvert {
                     chordstart = tempchordline.length();
                 }
                 for (int z = tempchordline.length(); z < (chordstart-1); z++) {
-                    tempchordline.append(" ");
+                    tempchordline = tempchordline + " ";
                 }
                 // Now add the chord
-                tempchordline.append(chord);
+                tempchordline = tempchordline + chord;
             }
             // All chords should be gone now, so remove any remaining [ and ]
             s = s.replace("[", "");
@@ -539,97 +607,97 @@ class ChordProConvert {
     }
 
     private static String fixHeadings(String s) {
-	    s = s.replace(";[","[");
-	    s = s.replace("#[","[");
-	    return s;
+        s = s.replace(";[","[");
+        s = s.replace("#[","[");
+        return s;
     }
 
     static String fromOpenSongToChordPro(String lyrics, Context c) {
-		// This receives the text from the edit song lyrics editor and changes the format
-		// Allows users to enter their song as chordpro/onsong format
-		// The app will convert it into OpenSong before saving.
-		StringBuilder newlyrics = new StringBuilder();
+        // This receives the text from the edit song lyrics editor and changes the format
+        // Allows users to enter their song as chordpro/onsong format
+        // The app will convert it into OpenSong before saving.
+        String newlyrics = "";
 
-		// Split the lyrics into separate lines
-		String[] lines = lyrics.split("\n");
-		ArrayList<String> type = new ArrayList<>();
-		int linenums = lines.length;
+        // Split the lyrics into separate lines
+        String[] lines = lyrics.split("\n");
+        ArrayList<String> type = new ArrayList<>();
+        int linenums = lines.length;
 
-		// Determine the line types
-		for (String l:lines) {
-			type.add(ProcessSong.determineLineTypes(l,c));
-		}
+        // Determine the line types
+        for (String l:lines) {
+            type.add(ProcessSong.determineLineTypes(l,c));
+        }
 
         boolean dealingwithchorus = false;
 
         // Go through each line and add the appropriate lyrics with chords in them
-		for (int y = 0; y < linenums; y++) {
-		    // Go through the section a line at a time
+        for (int y = 0; y < linenums; y++) {
+            // Go through the section a line at a time
             String thislinetype;
-			String nextlinetype = "";
-			String previouslinetype = "";
-			thislinetype = type.get(y);
-			if (y < linenums - 1) {
-				nextlinetype = type.get(y+1);
-			}
-			if (y > 0) {
-				previouslinetype = type.get(y-1);
-			}
+            String nextlinetype = "";
+            String previouslinetype = "";
+            thislinetype = type.get(y);
+            if (y < linenums - 1) {
+                nextlinetype = type.get(y+1);
+            }
+            if (y > 0) {
+                previouslinetype = type.get(y-1);
+            }
 
-			String[] positions_returned;
-			String[] chords_returned;
-			String[] lyrics_returned;
+            String[] positions_returned;
+            String[] chords_returned;
+            String[] lyrics_returned;
 
-			switch (ProcessSong.howToProcessLines(y, linenums, thislinetype, nextlinetype, previouslinetype)) {
-				// If this is a chord line followed by a lyric line.
-				case "chord_then_lyric":
-					if (lines[y].length() > lines[y+1].length()) {
-						lines[y+1] = ProcessSong.fixLineLength(lines[y+1], lines[y].length());
-					}
-					positions_returned = ProcessSong.getChordPositions(lines[y]);
-					// Remove the . at the start of the line
+            switch (ProcessSong.howToProcessLines(y, linenums, thislinetype, nextlinetype, previouslinetype)) {
+                // If this is a chord line followed by a lyric line.
+                case "chord_then_lyric":
+                    if (lines[y].length() > lines[y+1].length()) {
+                        lines[y+1] = ProcessSong.fixLineLength(lines[y+1], lines[y].length());
+                    }
+                    positions_returned = ProcessSong.getChordPositions(lines[y]);
+                    // Remove the . at the start of the line
                     if (lines[y].startsWith(".")) {
                         lines[y] = lines[y].replaceFirst("."," ");
                     }
-					chords_returned = ProcessSong.getChordSections(lines[y], positions_returned);
-					lyrics_returned = ProcessSong.getLyricSections(lines[y + 1], positions_returned);
-					for (int w = 0; w < lyrics_returned.length; w++) {
-						String chord_to_add = "";
-						if (w<chords_returned.length) {
-							if (chords_returned[w] != null && !chords_returned[w].trim().equals("")) {
-							    if (chords_returned[w].trim().startsWith(".") || chords_returned[w].trim().startsWith("|") ||
+                    chords_returned = ProcessSong.getChordSections(lines[y], positions_returned);
+                    lyrics_returned = ProcessSong.getLyricSections(lines[y + 1], positions_returned);
+                    for (int w = 0; w < lyrics_returned.length; w++) {
+                        String chord_to_add = "";
+                        if (w<chords_returned.length) {
+                            if (chords_returned[w] != null && !chords_returned[w].trim().equals("")) {
+                                if (chords_returned[w].trim().startsWith(".") || chords_returned[w].trim().startsWith("|") ||
                                         chords_returned[w].trim().startsWith(":")) {
-							        chord_to_add = chords_returned[w];
+                                    chord_to_add = chords_returned[w];
                                 } else {
                                     chord_to_add = "[" + chords_returned[w].trim() + "]";
                                 }
-							}
-						} else {
-							chord_to_add = "";
-						}
-						newlyrics.append(chord_to_add).append(lyrics_returned[w]);
-					}
-					break;
+                            }
+                        } else {
+                            chord_to_add = "";
+                        }
+                        newlyrics += chord_to_add + lyrics_returned[w];
+                    }
+                    break;
 
-				case "chord_only":
-					positions_returned = ProcessSong.getChordPositions(lines[y]);
-					chords_returned = ProcessSong.getChordSections(lines[y], positions_returned);
-					for (String aChords_returned : chords_returned) {
-						String chord_to_add = "";
-						if (aChords_returned != null && !aChords_returned.trim().equals("")) {
-							chord_to_add = "[" + aChords_returned.trim() + "]";
-						}
-						newlyrics.append(chord_to_add);
-					}
-					break;
+                case "chord_only":
+                    positions_returned = ProcessSong.getChordPositions(lines[y]);
+                    chords_returned = ProcessSong.getChordSections(lines[y], positions_returned);
+                    for (String aChords_returned : chords_returned) {
+                        String chord_to_add = "";
+                        if (aChords_returned != null && !aChords_returned.trim().equals("")) {
+                            chord_to_add = "[" + aChords_returned.trim() + "]";
+                        }
+                        newlyrics += chord_to_add;
+                    }
+                    break;
 
-				case "lyric_no_chord":
-					newlyrics.append(lines[y]);
-					break;
+                case "lyric_no_chord":
+                    newlyrics += lines[y];
+                    break;
 
-				case "comment_no_chord":
-					newlyrics.append("{c:").append(lines[y]).append("}");
-					break;
+                case "comment_no_chord":
+                    newlyrics += "{c:" + lines[y]+ "}";
+                    break;
 
                 case "heading":
                     // If this is a chorus, deal with it appropriately
@@ -637,41 +705,41 @@ class ChordProConvert {
 
                     if (lines[y].startsWith("[C")) {
                         dealingwithchorus = true;
-                        newlyrics.append("{soc}\n#").append(lines[y]);
+                        newlyrics += "{soc}\n#"+lines[y];
                     } else {
                         if (dealingwithchorus) {
                             // We've finished with the chorus,
                             dealingwithchorus = false;
-                            newlyrics.append("{eoc}\n" + "#").append(lines[y]);
+                            newlyrics += "{eoc}\n"+"#"+lines[y];
                         } else {
-                            newlyrics.append("#").append(lines[y]);
+                            newlyrics += "#"+lines[y];
                         }
                     }
                     break;
-			}
-			newlyrics.append("\n");
+            }
+            newlyrics += "\n";
 
-		}
-        newlyrics.append("\n");
-        newlyrics = new StringBuilder(newlyrics.toString().replace("\n\n{eoc}", "\n{eoc}\n"));
-        newlyrics = new StringBuilder(newlyrics.toString().replace("\n \n{eoc}", "\n{eoc}\n"));
-        newlyrics = new StringBuilder(newlyrics.toString().replace("\n\n{eoc}", "\n{eoc}\n"));
-        newlyrics = new StringBuilder(newlyrics.toString().replace("\n \n{eoc}", "\n{eoc}\n"));
-        newlyrics = new StringBuilder(newlyrics.toString().replace("][", "]  ["));
-        newlyrics = new StringBuilder(newlyrics.toString().replace("\n\n", "\n"));
+        }
+        newlyrics += "\n";
+        newlyrics = newlyrics.replace("\n\n{eoc}","\n{eoc}\n");
+        newlyrics = newlyrics.replace("\n \n{eoc}","\n{eoc}\n");
+        newlyrics = newlyrics.replace("\n\n{eoc}","\n{eoc}\n");
+        newlyrics = newlyrics.replace("\n \n{eoc}","\n{eoc}\n");
+        newlyrics = newlyrics.replace("][","]  [");
+        newlyrics = newlyrics.replace("\n\n","\n");
 
-        if (newlyrics.toString().startsWith("\n")) {
-            newlyrics = new StringBuilder(newlyrics.toString().replaceFirst("\n", ""));
+        if (newlyrics.startsWith("\n")) {
+            newlyrics = newlyrics.replaceFirst("\n","");
         }
 
-		return newlyrics.toString();
-	}
+        return newlyrics;
+    }
 
-	static String fromChordProToOpenSong(String lyrics) {
+    static String fromChordProToOpenSong(String lyrics) {
         // This receives the text from the edit song lyrics editor and changes the format
         // This changes ChordPro formatted songs back to OpenSong format
         // The app will convert it into OpenSong before saving.
-        StringBuilder newlyrics = new StringBuilder();
+        String newlyrics = "";
 
         // Split the lyrics into separate lines
         String[] line = lyrics.split("\n");
@@ -689,9 +757,9 @@ class ChordProConvert {
             // Join the individual lines back up (unless they are start/end of chorus)
             if (!line[x].contains("{start_of_chorus}") && !line[x].contains("{soc}") &&
                     !line[x].contains("{end_of_chorus}") && !line[x].contains("{eoc}")) {
-                newlyrics.append(line[x]).append("\n");
+                newlyrics = newlyrics + line[x] + "\n";
             }
         }
-		return newlyrics.toString();
-	}
+        return newlyrics;
+    }
 }


### PR DESCRIPTION
 Issue related to extra space in the beggining of the line , then the line was taken has lyrics because the symbol searched was at index 1, not 0. Also content on tags {start_of_bridge} was eliminated after convert from chordpro to opensong.

Then, when the song is in display shows [C] instead of chorus and a extra [].

![imagen](https://user-images.githubusercontent.com/9680477/44315595-3a4cd500-a3fc-11e8-82fc-06404df4e5c5.png)

![imagen](https://user-images.githubusercontent.com/9680477/44315599-4042b600-a3fc-11e8-98dd-211829aa50db.png)

I modified the code to check correctly if the line contains lyrics or a directive removing the extra space temporaly. Also added directives {start_of_bridge} and {end_of_bridge}.

Now the conversion from chordpro to opensong works fine.