### PR TITLE
Fix extraction of superscript characters from SongSelect

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
@@ -1342,7 +1342,9 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
         }
         return "";
     }
-    private String getLyricsSongSelectChordPro(String s) {
+    protected String getLyricsSongSelectChordPro(String s) {
+        s = s.replace("<sup>", "").replace("</sup>", "");
+
         int start = s.indexOf("<pre class=\"cproSongBody\">");
         int end = s.indexOf("</pre>",start);
         if (start>-1 && end>-1 && end>start) {

--- a/app/src/test/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragmentTests.java
+++ b/app/src/test/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragmentTests.java
@@ -1,0 +1,39 @@
+package com.garethevans.church.opensongtablet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class PopUpFindNewSongsFragmentTests extends PopUpFindNewSongsFragment {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                { /*input:*/ "<pre class=\"cproSongBody\"><span class=\"chordWrapper\"><code class=\"chord\" data-chordname=\"A\">A</code><span class=\"chordLyrics\">Text</span></span></pre>",
+                        /*expected:*/ "[A]Text", "#01" },
+                { /*input:*/ "<pre class=\"cproSongBody\"><span class=\"chordWrapper\"><code class=\"chord\" data-chordname=\"F#m<sup>7</sup>\">F#m<sup>7</sup></code><span class=\"chordLyrics\">Text</span></span></pre>",
+                        /*expected:*/ "[F#m7]Text", "#02" },
+        });
+    }
+
+    @Parameterized.Parameter // first data value (0) is default
+    public String input;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Parameterized.Parameter(2)
+    public String message;
+
+    @Test
+    public void getLyricsSongSelectChordPro_ExtractsChordCorrectly() {
+        assertEquals(message + " Input: '" + input + "'", expected, getLyricsSongSelectChordPro(input));
+    }
+
+}


### PR DESCRIPTION
- recently when importing songs from SongSelect the chords were messed
  up because of sprinkled sup tags in the text. This change removes
  the superfluous tags.
- also add some unit tests for the chord extraction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thebigg73/opensongtablet/61)
<!-- Reviewable:end -->
