### PR TITLE
Page change protect / fixes

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
@@ -183,7 +183,7 @@ class ExportPreparer {
         Uri onsong = null;
         Uri image = null;
         Uri pdf = null;
-        Bitmap pdfbmp = bmp.copy(bmp.getConfig(),true);
+        // IV - Moved pdfbmp into relevant PDF section
 
         // Prepare the song uri and input stream
         Uri uriinput = storageAccess.getUriForItem(c, preferences, "Songs", StaticVariables.whichSongFolder,
@@ -258,6 +258,20 @@ class ExportPreparer {
             storageAccess.writeFileFromString(exportOnSong_String,outputStream);
         }
 
+        // IV - Image based exports  - did not investigate why but swapped position of PDF with PNG to get them working when both selected
+        if (StaticVariables.whichMode.equals("Performance") && preferences.getMyPreferenceBoolean(c,"exportPDF",false)) {
+            // Prepare a pdf version of the song.
+            pdf = storageAccess.getUriForItem(c, preferences, "Export", "",
+                    StaticVariables.songfilename+".pdf");
+
+            // Check the uri exists for the outputstream to be valid
+            storageAccess.lollipopCreateFileForOutputStream(c, preferences, pdf, null, "Export", "", StaticVariables.songfilename + ".pdf");
+
+            Bitmap pdfbmp = bmp.copy(bmp.getConfig(),true);
+
+            makePDF(c,pdfbmp,pdf,storageAccess);
+        }
+
         if (StaticVariables.whichMode.equals("Performance") &&
                 preferences.getMyPreferenceBoolean(c,"exportImage",false)) {
             // Prepare an image/png version of the song.
@@ -269,14 +283,6 @@ class ExportPreparer {
 
             OutputStream outputStream = storageAccess.getOutputStream(c,image);
             storageAccess.writeImage(outputStream, bmp);
-        }
-
-        if (StaticVariables.whichMode.equals("Performance") && preferences.getMyPreferenceBoolean(c,"exportPDF",false)) {
-            // Prepare a pdf version of the song.
-            pdf = storageAccess.getUriForItem(c, preferences, "Export", "",
-                    StaticVariables.songfilename+".pdf");
-            storageAccess.lollipopCreateFileForOutputStream(c, preferences, pdf, null, "Export", "", StaticVariables.songfilename + ".pdf");
-            makePDF(c,pdfbmp,pdf,storageAccess);
         }
 
         Intent emailIntent = setEmailIntent(StaticVariables.songfilename, StaticVariables.songfilename,
@@ -832,11 +838,12 @@ class ExportPreparer {
 
         // Go through each song section and add the text trimmed lines
         for (int f = 0; f< StaticVariables.songSections.length; f++) {
-            s.append(processSong.songSectionText(c, preferences, f));
+            // IV - Separate sections by a line breaks - to correctly layout txt output
+            s.append(processSong.songSectionText(c, preferences, f)).append("\n\n");
         }
 
         String string = s.toString();
-        string = string.replace("\n\n\n", "\n\n");
+        string = string.replaceAll("\n\n\n", "\n\n");
         return string;
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpAutoscrollFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpAutoscrollFragment.java
@@ -209,7 +209,6 @@ public class PopUpAutoscrollFragment extends DialogFragment {
                 boolean b = popupautoscroll_startstopbutton.getText() == Objects.requireNonNull(getActivity()).getResources().getString(R.string.start);
                 // Request a start/stop if needed to get to the chosen state
                 if ((!StaticVariables.isautoscrolling && b) || (StaticVariables.isautoscrolling && !b)) {
-                    StaticVariables.doVibrateActive = false;
                     mListener.gesture5();
                 }
                         PopUpAutoscrollFragment.this.dismiss();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpExportFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpExportFragment.java
@@ -117,8 +117,9 @@ public class PopUpExportFragment extends DialogFragment {
         // Set the checkboxes to their last set value
         exportOpenSongAppSetCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportOpenSongAppSet",true));
         exportOpenSongAppCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportOpenSongApp",true));
-        exportDesktopCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportOpenSongAppSet",false));
-        exportTextCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportOpenSongText",true));
+        // IV - preference name corrections
+        exportDesktopCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportDesktop",false));
+        exportTextCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportText",true));
         exportChordProCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportChordPro",false));
         exportOnSongCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportOnSong",false));
         exportImageCheckBox.setChecked(preferences.getMyPreferenceBoolean(getActivity(),"exportImage",false));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -48,6 +48,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
@@ -378,6 +379,9 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
 
             // Initialise the ab info
             adjustABInfo();
+
+            // Setup the options drawer reset on close
+            setupOptionDrawerReset();
 
             // Click on the first item in the set
             if (presenter_set_buttonsListView.getChildCount() > 0) {
@@ -4126,5 +4130,24 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             }
         }
         startActivityForResult(intent, StaticVariables.REQUEST_FILE_CHOOSER);
+    }
+
+    // IV - Make option menu return to MAIN after use - same as for other modes
+    private void setupOptionDrawerReset() {
+        // Called when a drawer has settled in a completely open state.
+        ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(PresenterMode.this, mDrawerLayout, ab_toolbar, R.string.drawer_open, R.string.drawer_close) {
+            // Called when a drawer has settled in a completely closed state.
+            @Override
+            public void onDrawerClosed(View view) {
+                super.onDrawerClosed(view);
+                // Set a runnable to return option menu to MAIN, This ensures 'Activated/Running' in sub menus work properly
+                Handler resetoptionmenu = new Handler();
+                resetoptionmenu.postDelayed(() -> {
+                    StaticVariables.whichOptionMenu = "MAIN";
+                    prepareOptionMenu();
+                }, 300);
+            }
+        };
+        mDrawerLayout.addDrawerListener(actionBarDrawerToggle);
     }
 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -1274,6 +1274,9 @@ public class ProcessSong extends Activity {
         lyricrow.setClipChildren(false);
         lyricrow.setClipToPadding(false);
 
+        // IV - Used when a lyricsOnly song is processed
+        boolean lyricsOnly = false;
+
         for (String bit:lyrics) {
             String imagetext;
             if ((bit.toLowerCase(Locale.ROOT).endsWith(".png") || bit.toLowerCase(Locale.ROOT).endsWith(".jpg") ||
@@ -1290,7 +1293,15 @@ public class ProcessSong extends Activity {
                     bit = bit.replace("_", "");
                 } else if ((StaticVariables.whichMode.equals("Stage") || StaticVariables.whichMode.equals("Performance")) &&
                         !preferences.getMyPreferenceBoolean(c,"displayChords",true)) {
-                    bit = bit.replace("_", "");
+                    // IV - Lyric line only so assemble and do the line in one go.  Remove typical word splits and white space - beautify!
+                    final StringBuilder sb = new StringBuilder();
+                    sb.append(lyrics[0]);
+                    for (int i = 1; i < lyrics.length; i++) {
+                        sb.append(lyrics[i]);
+                    }
+                    bit = sb.toString().replaceAll("_", "").replaceAll("\\s+-\\s+", "").replaceAll("\\s{2,}", " ").trim();
+                    // IV - flag used to break loop
+                    lyricsOnly = true;
                 } else {
                     bit = bit.replace("_", " ");
                 }
@@ -1394,6 +1405,10 @@ public class ProcessSong extends Activity {
                     lyricbit.setLineSpacing(0f, 0f);
                 }
                 lyricrow.addView(lyricbit);
+            }
+            // IV quick exit after doing a lyrics only line in one go above
+            if (lyricsOnly) {
+                break;
             }
         }
         return lyricrow;
@@ -2152,7 +2167,8 @@ public class ProcessSong extends Activity {
                     StaticVariables.sectionContents[x][y].startsWith(" ") ||
                     StaticVariables.sectionContents[x][y].startsWith(".") ||
                     StaticVariables.sectionContents[x][y].startsWith(";")) {
-                text.append(StaticVariables.sectionContents[x][y].substring(1));
+                // IV - Replace leading character with space to keep correct txt alignment
+                text.append(" ").append(StaticVariables.sectionContents[x][y].substring(1));
             } else {
                 text.append(StaticVariables.sectionContents[x][y]);
             }


### PR DESCRIPTION
GE Pull request to test branch before master

Fixes:
1. Adjustments page change protection to apply across folders/sets and extended to all song types with fix of missing set buttons if feature not in use.
2. Song export
- corrections to typos for preference names in popup (options now save)
- txt export layout corrections for section breaks and chords alignment
- Resolved conflict PDF and png process preventing correct export
3. presentation mode option menu returns to 'MAIN' after use (same as recent Stage mode change).

Enhancements:
1. Autoscroll will pause on any pedal use.  A user can configure a long press scroll up to go to the top of the song and keep it pressed to hold the song paused at the top.
On releasing the pedal autoscroll will start.  This gives manual control over when autoscroll starts.
2. A lyrics only song display will compress white space and remove word splits of format " - " (at least one space on either side.  An attempt to further beautify.