### PR TITLE
Fixes

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -308,9 +308,10 @@ class ChordProConvert {
     String extractChordLines(String s) {
         StringBuilder tempchordline = new StringBuilder();
         if (!s.startsWith("#") && !s.startsWith(";")) {
+            // IV - Add a leading space - the effect is to fix a chord mis-alignment
+            s = " " + s;
             // Look for [ and ] signifying a chord
             while (s.contains("[") && s.contains("]")) {
-
                 // Find chord start and end pos
                 int chordstart = s.indexOf("[");
                 int chordend = s.indexOf("]");
@@ -344,12 +345,7 @@ class ChordProConvert {
             // All chords should be gone now, so remove any remaining [ and ]
             s = s.replace("[", "");
             s = s.replace("]", "");
-            if (!s.startsWith(" ")) {
-                s = " " + s;
-                if (tempchordline.length() > 0) {
-                    tempchordline.insert(0, " ");
-                }
-            }
+            // IV - fix for missing space removed as now handled before loop
             if (tempchordline.length() > 0) {
                 s = "." + tempchordline + "\n" + s;
             }
@@ -906,10 +902,19 @@ class ChordProConvert {
             line[x] = guessTags(line[x]);
             line[x] = extractCommentLines(line[x]);
 
+            // IV - Treat start of chorus as a comment - allows song autofix to fix when it fixes comments
+            line[x] = line[x].replace("{start_of_chorus}",";Chorus");
 
-            // Join the individual lines back up (unless they are start/end of chorus)
-            if (!line[x].contains("{start_of_chorus}") && !line[x].contains("{soc}") &&
-                    !line[x].contains("{end_of_chorus}") && !line[x].contains("{eoc}")) {
+            // IV - For unprocessed lines add a leading space - a fix for mis-aligned lyric only lines
+            if (line[x].length() > 0) {
+                String test = ";. {";
+                if (!test.contains(line[x].substring(0,1))) {
+                    line[x] = " " + line[x];
+                }
+            }
+
+            // Join the individual lines back up (unless they are end of chorus)
+            if (!line[x].contains("{end_of_chorus}") && !line[x].contains("{eoc}")) {
                 newlyrics.append(line[x]).append("\n");
             }
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -3888,68 +3888,71 @@ public class StageMode extends AppCompatActivity implements
 
     @Override
     public void goToNextItem() {
-        FullscreenActivity.whichDirection = "R2L";
-        boolean dealtwithaspdf = false;
-        StaticVariables.showstartofpdf = true;
+        // IV - Stops errors on rapid song changes
+        if (!FullscreenActivity.alreadyloading) {
+            FullscreenActivity.whichDirection = "R2L";
+            boolean dealtwithaspdf = false;
+            StaticVariables.showstartofpdf = true;
 
-        // If this is a PDF, check we can't move pages
-        if (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent < (FullscreenActivity.pdfPageCount - 1)) {
-            FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent + 1;
+            // If this is a PDF, check we can't move pages
+            if (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent < (FullscreenActivity.pdfPageCount - 1)) {
+                FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent + 1;
 
-            // Load the next pdf page
-            dealtwithaspdf = true;
-            loadSong();
+                // Load the next pdf page
+                dealtwithaspdf = true;
+                loadSong();
 
-        } else {
-            FullscreenActivity.pdfPageCurrent = 0;
-        }
-
-        // If this hasn't been dealt with
-        if (!dealtwithaspdf && StaticVariables.setView) {
-            // Is there another song in the set?  If so move, if not, do nothing
-            // IV - Now made song section aware for Stage mode
-            if ((StaticVariables.indexSongInSet < StaticVariables.mSetList.length - 1) ||
-                    (StaticVariables.whichMode.equals("Stage") && StaticVariables.songSections != null && StaticVariables.currentSection < StaticVariables.songSections.length - 1)) {
-                //FullscreenActivity.indexSongInSet += 1;
-                StaticVariables.setMoveDirection = "forward";
-                doMoveInSet();
             } else {
-                showToastMessage(getResources().getString(R.string.lastsong));
-            }
-        } else if (!dealtwithaspdf) {
-            // Try to move to the next song alphabetically
-            // However, only do this if the previous item isn't a subfolder!
-            boolean isfolder = false;
-            try {
-                if (FullscreenActivity.nextSongIndex < filenamesSongsInFolder.size() && FullscreenActivity.nextSongIndex>-1) {
-
-                    Uri uri = storageAccess.getUriForItem(StageMode.this, preferences, "Songs", "",
-                            filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex));
-                    if (storageAccess.uriExists(StageMode.this, uri) && !storageAccess.uriIsFile(StageMode.this, uri)) {
-                        isfolder = true;
-                    }
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+                FullscreenActivity.pdfPageCurrent = 0;
             }
 
-            try {
-                if (FullscreenActivity.nextSongIndex < filenamesSongsInFolder.size()
-                        && FullscreenActivity.nextSongIndex != -1
-                        && !StaticVariables.songfilename.equals(filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex)) &&
-                        !isfolder) {
-                    FullscreenActivity.tempswipeSet = "disable";
-                    StaticVariables.songfilename = filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex);
-                    loadSong();
-
-                    // Set a runnable to reset swipe back to original value after 1 second
-                    Handler delayfadeinredraw = new Handler();
-                    delayfadeinredraw.postDelayed(() -> FullscreenActivity.tempswipeSet = "enable", FullscreenActivity.delayswipe_time);
+            // If this hasn't been dealt with
+            if (!dealtwithaspdf && StaticVariables.setView) {
+                // Is there another song in the set?  If so move, if not, do nothing
+                // IV - Now made song section aware for Stage mode
+                if ((StaticVariables.indexSongInSet < StaticVariables.mSetList.length - 1) ||
+                        (StaticVariables.whichMode.equals("Stage") && StaticVariables.songSections != null && StaticVariables.currentSection < StaticVariables.songSections.length - 1)) {
+                    //FullscreenActivity.indexSongInSet += 1;
+                    StaticVariables.setMoveDirection = "forward";
+                    doMoveInSet();
                 } else {
                     showToastMessage(getResources().getString(R.string.lastsong));
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
+            } else if (!dealtwithaspdf) {
+                // Try to move to the next song alphabetically
+                // However, only do this if the previous item isn't a subfolder!
+                boolean isfolder = false;
+                try {
+                    if (FullscreenActivity.nextSongIndex < filenamesSongsInFolder.size() && FullscreenActivity.nextSongIndex > -1) {
+
+                        Uri uri = storageAccess.getUriForItem(StageMode.this, preferences, "Songs", "",
+                                filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex));
+                        if (storageAccess.uriExists(StageMode.this, uri) && !storageAccess.uriIsFile(StageMode.this, uri)) {
+                            isfolder = true;
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                try {
+                    if (FullscreenActivity.nextSongIndex < filenamesSongsInFolder.size()
+                            && FullscreenActivity.nextSongIndex != -1
+                            && !StaticVariables.songfilename.equals(filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex)) &&
+                            !isfolder) {
+                        FullscreenActivity.tempswipeSet = "disable";
+                        StaticVariables.songfilename = filenamesSongsInFolder.get(FullscreenActivity.nextSongIndex);
+                        loadSong();
+
+                        // Set a runnable to reset swipe back to original value after 1 second
+                        Handler delayfadeinredraw = new Handler();
+                        delayfadeinredraw.postDelayed(() -> FullscreenActivity.tempswipeSet = "enable", FullscreenActivity.delayswipe_time);
+                    } else {
+                        showToastMessage(getResources().getString(R.string.lastsong));
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
     }
@@ -4402,65 +4405,68 @@ public class StageMode extends AppCompatActivity implements
 
     @Override
     public void goToPreviousItem() {
-        FullscreenActivity.whichDirection = "L2R";
-        boolean dealtwithaspdf = false;
-        StaticVariables.showstartofpdf = true; // Default value - change later if need be
+        // IV - Stops errors on rapid song changes
+        if (!FullscreenActivity.alreadyloading) {
+            FullscreenActivity.whichDirection = "L2R";
+            boolean dealtwithaspdf = false;
+            StaticVariables.showstartofpdf = true; // Default value - change later if need be
 
-        // If this is a PDF, check we can't move pages
-        if (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0) {
-            FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent - 1;
-            dealtwithaspdf = true;
-            loadSong();
-        } else {
-            FullscreenActivity.pdfPageCurrent = 0;
-        }
-
-        // If this hasn't been dealt with
-        if (!dealtwithaspdf && StaticVariables.setView) {
-            StaticVariables.showstartofpdf = false; // Moving backwards, so start at end of pdf
-            // IV - Now made song section aware for Stage mode
-            // Is there another song in the set?  If so move, if not, do nothing
-            if ((StaticVariables.indexSongInSet > 0 && StaticVariables.mSetList.length > 0) ||
-                    (StaticVariables.whichMode.equals("Stage") && StaticVariables.songSections != null && StaticVariables.currentSection > 0)) {
-                //FullscreenActivity.indexSongInSet -= 1;
-                StaticVariables.setMoveDirection = "back";
-                doMoveInSet();
+            // If this is a PDF, check we can't move pages
+            if (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0) {
+                FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent - 1;
+                dealtwithaspdf = true;
+                loadSong();
             } else {
-                showToastMessage(getResources().getString(R.string.firstsong));
+                FullscreenActivity.pdfPageCurrent = 0;
             }
-        } else if (!dealtwithaspdf) {
-            // Try to move to the previous song alphabetically
-            // However, only do this if the previous item isn't a subfolder!
-            boolean isfolder = false;
-            if (FullscreenActivity.previousSongIndex >= 0) {
+
+            // If this hasn't been dealt with
+            if (!dealtwithaspdf && StaticVariables.setView) {
+                StaticVariables.showstartofpdf = false; // Moving backwards, so start at end of pdf
+                // IV - Now made song section aware for Stage mode
+                // Is there another song in the set?  If so move, if not, do nothing
+                if ((StaticVariables.indexSongInSet > 0 && StaticVariables.mSetList.length > 0) ||
+                        (StaticVariables.whichMode.equals("Stage") && StaticVariables.songSections != null && StaticVariables.currentSection > 0)) {
+                    //FullscreenActivity.indexSongInSet -= 1;
+                    StaticVariables.setMoveDirection = "back";
+                    doMoveInSet();
+                } else {
+                    showToastMessage(getResources().getString(R.string.firstsong));
+                }
+            } else if (!dealtwithaspdf) {
+                // Try to move to the previous song alphabetically
+                // However, only do this if the previous item isn't a subfolder!
+                boolean isfolder = false;
+                if (FullscreenActivity.previousSongIndex >= 0) {
+                    try {
+                        Uri uri = storageAccess.getUriForItem(StageMode.this, preferences, "Songs", "",
+                                filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex));
+                        if (storageAccess.uriExists(StageMode.this, uri) && !storageAccess.uriIsFile(StageMode.this, uri)) {
+                            isfolder = true;
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+
                 try {
-                    Uri uri = storageAccess.getUriForItem(StageMode.this, preferences, "Songs", "",
-                            filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex));
-                    if (storageAccess.uriExists(StageMode.this, uri) && !storageAccess.uriIsFile(StageMode.this, uri)) {
-                        isfolder = true;
+                    if (FullscreenActivity.previousSongIndex >= 0 && filenamesSongsInFolder.size()>FullscreenActivity.previousSongIndex
+                            && !StaticVariables.songfilename.equals(filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex))
+                            && !isfolder) {
+                        FullscreenActivity.tempswipeSet = "disable";
+
+                        StaticVariables.songfilename = filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex);
+                        loadSong();
+
+                        // Set a runnable to reset swipe back to original value after 1 second
+                        Handler delayfadeinredraw = new Handler();
+                        delayfadeinredraw.postDelayed(() -> FullscreenActivity.tempswipeSet = "enable", FullscreenActivity.delayswipe_time);
+                    } else {
+                        showToastMessage(getResources().getString(R.string.firstsong));
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-            }
-
-            try {
-                if (FullscreenActivity.previousSongIndex >= 0 && filenamesSongsInFolder.size()>FullscreenActivity.previousSongIndex
-                        && !StaticVariables.songfilename.equals(filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex))
-                        && !isfolder) {
-                    FullscreenActivity.tempswipeSet = "disable";
-
-                    StaticVariables.songfilename = filenamesSongsInFolder.get(FullscreenActivity.previousSongIndex);
-                    loadSong();
-
-                    // Set a runnable to reset swipe back to original value after 1 second
-                    Handler delayfadeinredraw = new Handler();
-                    delayfadeinredraw.postDelayed(() -> FullscreenActivity.tempswipeSet = "enable", FullscreenActivity.delayswipe_time);
-                } else {
-                    showToastMessage(getResources().getString(R.string.firstsong));
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
             }
         }
     }
@@ -5928,6 +5934,14 @@ public class StageMode extends AppCompatActivity implements
 
     @Override
     public void openFragment() {
+        // IV - Block false short key press if fragment used during long press
+        StaticVariables.blockActionOnKeyUp = true;
+        Handler resetBlockActionOnKeyUp = new Handler();
+        resetBlockActionOnKeyUp.postDelayed(() -> {
+            StaticVariables.blockActionOnKeyUp = false;
+            prepareOptionMenu();
+        }, 300);
+
         // Load the whichSongFolder in case we were browsing elsewhere
         StaticVariables.whichSongFolder = preferences.getMyPreferenceString(StageMode.this,"whichSongFolder",getString(R.string.mainfoldername));
 
@@ -7575,8 +7589,14 @@ public class StageMode extends AppCompatActivity implements
             doAirTurnShortOrLongPressListen(keyCode, event);
             return false;
         } else {
-            doShortPressAction(keyCode, event);
-            return true;
+            // IV - Block false short key press if fragment used during long press
+            if (StaticVariables.blockActionOnKeyUp) {
+                StaticVariables.blockActionOnKeyUp = false;
+                return false;
+            } else {
+                doShortPressAction(keyCode, event);
+                return true;
+            }
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StaticVariables.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StaticVariables.java
@@ -168,6 +168,7 @@ class StaticVariables {
     static boolean canGoToNext = false;
     static boolean canGoToPrevious = false;
     static boolean doVibrateActive = true;
+    static boolean blockActionOnKeyUp = false;
     static int scrollpageHeight;
     static int total_pixels_to_scroll = 0;
     static final int autoscroll_pause_time = 500;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/TextSongConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/TextSongConvert.java
@@ -86,6 +86,8 @@ class TextSongConvert {
                 //Remove any double braces
                 l = l.replace("[[", "[");
                 l = l.replace("]]", "]");
+                // IV - Fix chordpro tags converted from comments
+                l = l.replace("[;","[");
             }
         }
 


### PR DESCRIPTION
1. Short key press seen when holding a pedal long press and using a fragment fixed.
   Fix: On fragment entry short key presses are temporarily ignored, the false key press is ignored in this period.
2. Rapid song changes can result in incorrect first/last song toast messages.
   Fix:  Code is confused by a song being partially loaded in the background.  Relevant next and previous code now runs only if not in the middle of a song load.
   Negatives: One or more changes in a rapid sequence of changes will be ignored
3. Corrections to chord and lyric positions for chordpro conversions.
Ian V