### PR TITLE
For consideration: A song info block 'extra information' block and right trim of song lines

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2039,7 +2039,7 @@ public class ProcessSong extends Activity {
         StringBuilder chopro = new StringBuilder();
         String[] heading = beautifyHeadings(StaticVariables.songSectionsLabels[x],c);
         if (onsong) {
-            // IV DOne in three places to handle sections without heading
+            // IV Done in three places to handle sections without heading
             if (heading[0].trim().equals("")) {
                 chopro.append("Custom:\n");
             } else {
@@ -2914,7 +2914,7 @@ public class ProcessSong extends Activity {
         if (sad.equals("T") && !StaticVariables.mNotes.equals("")) {
             // If we have song details to display put them before a left aligned note otherwise just right align the note.
             if (s.length() > 0) {
-                s.append(stickyNotes.toString().replace(";__" + c.getString(R.string.note) + ": " + ";__", ";" + c.getString(R.string.note) + ": ")).append("\n");
+                s.append(stickyNotes.toString().replace(";__" + c.getString(R.string.note) + ": " + ";__", ";" + c.getString(R.string.note) + ": "));
             } else {
                 s.append(stickyNotes.toString().replace(";__" + c.getString(R.string.note) + ": " + ";__", ";__" + c.getString(R.string.note) + ": ")).append("\n");
             }
@@ -2930,7 +2930,7 @@ public class ProcessSong extends Activity {
 
         if (sad.equals("B")) {
             if (!StaticVariables.mNotes.equals("")) {
-                FullscreenActivity.myLyrics = FullscreenActivity.myLyrics + "\n\n" + stickyNotes;
+                FullscreenActivity.myLyrics = FullscreenActivity.myLyrics + "\n\n" + stickyNotes.toString().replace(";__" + c.getString(R.string.note) + ": " + ";__", ";__" + c.getString(R.string.note) + ": ") + "\n";
             }
         }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -346,11 +346,6 @@ public class StageMode extends AppCompatActivity implements
     private Handler presoinfohandler;
     private Handler customhandler;
 
-    //TODO REMOVE
-    /*/
-    private ArrayList<String> connectedEndPoints;
-    private ArrayList<String> connectedEndPointsNames;*/
-
     // Network discovery / connections
     NearbyConnections nearbyConnections;
 
@@ -521,10 +516,6 @@ public class StageMode extends AppCompatActivity implements
             // Set up the Nearby connection service
             getBluetoothName();
             nearbyConnections.getUserNickname();
-
-            //TODO REMOVE
-            /*connectedEndPoints = new ArrayList<>();
-            connectedEndPointsNames = new ArrayList<>();*/
 
             dealWithIntent();
 
@@ -5431,6 +5422,7 @@ public class StageMode extends AppCompatActivity implements
             blockActionOnKeyUp = false;
         }, 300);
 
+
         // Load the whichSongFolder in case we were browsing elsewhere
         StaticVariables.whichSongFolder = preferences.getMyPreferenceString(StageMode.this,"whichSongFolder",getString(R.string.mainfoldername));
 
@@ -6886,8 +6878,6 @@ public class StageMode extends AppCompatActivity implements
                         doCancelAsyncTask(loadsong_async);
 
                         // Stop the metronome if loading a new song.  Trying afterwards stops the async starting!
-                        // TODO
-                        Log.d("d","loadSong()  StaticVariables.reloadOfSong="+StaticVariables.reloadOfSong + "  StaticVariables.clickedOnMetronomeStart="+StaticVariables.clickedOnMetronomeStart);
                         // Do not touch on a reload
                         if (!StaticVariables.reloadOfSong) {
                             // Stop it - clickedOnMetronomeStart is the indicator that it was playing


### PR DESCRIPTION
Hello Gareth,

I have been looking at exports and wanted to add a 'song details' block (as seen in txt outputs) to png and pdf exports.  This ended up being a song details block for on-screen and export use.  I think it also happily gives an option for users who want a more traditional on-screen printed page look (maybe).

I have also looked at right trim of lines for screen display (helps to maximise size and compensates for untidy imports).  I am less sure of the utility of this.  It did however allow me to put 2 spaces after lines - to reduce the right edge overruns that I occasionally see.

Hopefully something useful.

Kind regards
Ian V