### PR TITLE
ChordPro to OpenSong

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -749,6 +749,7 @@ class ChordProConvert {
                 s = guessTagsReplaces(s, "Verse", "V");
                 s = guessTagsReplaces(s, "Prechorus", "P");
                 s = guessTagsReplaces(s, "Pre-chorus", "P");
+                s = guessTagsReplaces(s, "Pre-Chorus", "P");
                 s = guessTagsReplaces(s, "Chorus", "C");
                 s = guessTagsReplaces(s, "Bridge", "B");
                 s = guessTagsReplaces(s, "Tag", "T");

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -52,9 +52,6 @@ class ChordProConvert {
         // Get rid of multilple line breaks (max of 3 together)
         lyrics = getRidOfExtraLines(lyrics);
 
-        // Add spaces to beginnings of lines that aren't comments, chords or tags
-        lyrics = addSpacesToLines(lyrics);
-
         // Get the filename and subfolder (if any) that the original song was in by parsing the uri
         oldSongFileName = getOldSongFileName(uri);
         songSubFolder = getSongFolderLocation(storageAccess, uri, oldSongFileName);
@@ -106,6 +103,7 @@ class ChordProConvert {
         if (s == null) {
             return "";
         }
+        s = s.replace("&amp;rsquo;", "'");
         s = s.replace("&amp;apos;", "'");
         s = s.replace("&amp;quote;", "\"");
         s = s.replace("&amp;quot;", "\"");
@@ -385,51 +383,103 @@ class ChordProConvert {
     }
 
     String extractChordLines(String s) {
+        // IV - ChordPro, by design, requires processing to improve layout when presented in chords over lyrics format
+        // IV - OpenSongApp adopts a SongSelect-ish approach to layout below
+        // IV - As a result, a SongSelect extract will have an OpenSong layout close to that of a SongSelect chord sheet (Yeah!)
+        // IV - All ChordPro files will get this layout - our layout may or may not be liked!
+
         StringBuilder tempchordline = new StringBuilder();
-        if (!s.startsWith("#") && !s.startsWith(";")) {
-            // IV - Add a leading space - the effect is to fix a chord mis-alignment
-            s = " " + s;
+        StringBuilder templyricline = new StringBuilder();
+        if (!s.startsWith("#") && !s.startsWith(";") && !s.startsWith("{")) {
+            int spos;
+            // IV - We need one [ for  processing of lines with no chords
+            s = s + "[";
+
+            // IV - Append  lyrics before [
+            spos = s.indexOf("[");
+            templyricline = templyricline.append(s.substring(0,spos));
+
+            s = s.substring(spos);
+
             // Look for [ and ] signifying a chord
             while (s.contains("[") && s.contains("]")) {
-                // Find chord start and end pos
-                int chordstart = s.indexOf("[");
-                int chordend = s.indexOf("]");
-                String chord;
-                if (chordend > chordstart) {
-                    chord = s.substring(chordstart, chordend + 1);
-                    String substart = s.substring(0, chordstart);
-                    String subsend = s.substring(chordend + 1);
-                    s = substart + subsend;
-                } else {
-                    chord = "";
-                    s = s.replace("[", "");
-                    s = s.replace("]", "");
+                // IV - Make lines the same length
+                for (int z = tempchordline.length(); z < (templyricline.length()); z++) tempchordline.append(" ");
+                for (int z = templyricline.length(); z < (tempchordline.length()); z++) templyricline.append(" ");
+
+                boolean chordStartsOverSpace = s.substring(s.indexOf("]")).startsWith("] ");
+
+                // IV - Ensure spacing between sections
+                if (tempchordline.length() > 0) {
+                    // IV - If we are at a space in the lyrics, make sure there is a double space or equivalent before the following chord
+                    while ((templyricline.toString().endsWith(" ") || chordStartsOverSpace) &&
+                            (!(tempchordline.toString().endsWith("  ") || tempchordline.toString().endsWith("| ") || tempchordline.toString().endsWith(": ")))) {
+                        tempchordline = tempchordline.append(" ");
+                        templyricline = templyricline.append(" ");
+                    }
+
+                    // IV - Make sure there is a space before a chord over a space
+                    if (chordStartsOverSpace && !templyricline.toString().endsWith(" ")) {
+                        tempchordline = tempchordline.append(" ");
+                        templyricline = templyricline.append(" ");
+                    }
                 }
-                chord = chord.replace("[", "");
-                chord = chord.replace("]", "");
 
                 // Add the chord to the tempchordline
-                if (tempchordline.length() > chordstart) {
-                    // We need to put the chord at the end stuff already there
-                    // Don't overwrite - This is because the length of the
-                    // previous chord is bigger than the lyrics following it
-                    chordstart = tempchordline.length();
+                spos = s.indexOf("]");
+                tempchordline = tempchordline.append(s.substring(1,spos));
+
+                boolean chordSeparator = (s.substring(1,2).matches("[|:]"));
+
+                // IV - Consider lyric spacing
+                // IV - chord starting over a space -> over all spaces with 1 following space
+                // IV - chord starting over a lyric part and also over a space' -> over starting lyric part and spaces with 2 following spaces
+                // IV - Spaces are inserted when needed
+
+                s = s.substring(spos + 1);
+
+                while (s.contains(" ") && s.indexOf(" ") < s.indexOf("[") && s.indexOf(" ") < (spos - 1)) {
+                    // IV - Add a space after the last space found - is this space is under the chord it is considered on the next loop
+                    // IV - This intentionally ensures 1 lyric space following the chord
+                    s = s.replaceFirst(" ", "¦");
+                    if (s.indexOf("¦ ") == -1) {
+                        s = s.replace("¦", "¬ ");
+                    } else {
+                        s = s.replace("¦", "¬");
+                    }
                 }
-                for (int z = tempchordline.length(); z < (chordstart-1); z++) {
-                    tempchordline.append(" ");
+
+                // IV - Ensure there are 2 lyric spaces following a chord starting over a space
+                if (chordStartsOverSpace && !chordSeparator && !(s.contains("¬  "))) {
+                    s = s.replaceFirst("¬", "¬¬");
                 }
-                // Now add the chord
-                tempchordline.append(chord);
+
+                s = s.replaceAll("¬", " ");
+
+                // IV - Append lyrics before [
+                spos = s.indexOf("[");
+                templyricline = templyricline.append(s.substring(0, spos));
+
+                s = s.substring(spos);
             }
+
             // All chords should be gone now, so remove any remaining [ and ]
             s = s.replace("[", "");
             s = s.replace("]", "");
-            // IV - fix for missing space removed as now handled before loop
-            if (tempchordline.length() > 0) {
-                s = "." + tempchordline + "\n" + s;
+
+            // IV - Return lines end trimmed which keeps any intended leading spaces
+            if (tempchordline.toString().trim().equals("")) {
+                return (" " + templyricline.toString()).replaceAll("\\s+$", "");
+            } else {
+                if (templyricline.toString().trim().equals("")) {
+                    return ("." + tempchordline.toString()).replaceAll("\\s+$", "");
+                } else {
+                    return ("." + tempchordline.toString()).replaceAll("\\s+$", "") + "\n" + (" " + templyricline.toString()).replaceAll("\\s+$", "");
+                }
             }
         }
-        return s;
+        // IV - Return line end trimmed which keeps any intended leading spaces
+        return s.replaceAll("\\s+$", "");
     }
 
     String removeOtherTags(String l) {
@@ -487,29 +537,10 @@ class ChordProConvert {
             s = s.replace("[]\n\n[", "\n[");
         }
 
-        // IV - Trim and remove any trailing [] empty section
-        s = s.trim().replaceAll("\n\\Q[]\\E$","");
+        // IV - Remove any trailing [] empty section
+        s = s.replaceAll("\n\\Q[]\\E$","");
 
         return s;
-    }
-
-    String addSpacesToLines(String s) {
-        lines = s.split("\n");
-
-        // Reset the parsed lines
-        parsedLines = new StringBuilder();
-
-        for (String line : lines) {
-            line = line.trim();
-            if (!line.startsWith("[") && !line.startsWith(".") && !line.startsWith(";") && !s.equals("")) {
-                // Must be a lyric line, so add a space
-                line = " " + line;
-            }
-            line = line + "\n";
-            parsedLines.append(line);
-        }
-
-        return parsedLines.toString();
     }
 
     Uri getNewSongUri(Context c, StorageAccess storageAccess, Preferences preferences, String songSubFolder, String nsf) {
@@ -759,8 +790,13 @@ class ChordProConvert {
             replace(wm + " 4", "[¬ 4¹").
             replace(wm, "[¬¹");
 
-        // IV - A complete replace has '¹' at the end.
-        if (s.endsWith("¹")) {
+        s = s.replace(";[","[").
+            replace("#[","[").
+            replace("; [", "[").
+            replace(";- [", "[");
+
+        // IV - For a complete replace...
+        if (s.startsWith("[¬") && s.endsWith("¹")) {
             // IV - Single character 'start of returned heading' (V etc.) have no following space
             if (r.length() == 1) {
                 s = s.replace("¬ ", "¬");
@@ -781,14 +817,13 @@ class ChordProConvert {
         s = s.replace(";- [", "[");
         s = s.replace("-[", "[");
         s = s.replace("- [", "[");
-        s = s.trim();
         if (s.startsWith("[") && s.contains("]") && !s.endsWith("]")) {
             s = s.replace("]", "]\n");
         }
         if (s.contains("[") && s.contains("]") && !s.startsWith("[")) {
             s = s.replace("[", "\n[");
         }
-        return s.trim();
+        return s;
     }
 
     private String removeStartOfEndOfTags(String s) {
@@ -815,7 +850,7 @@ class ChordProConvert {
             // Replace end tags with blank tag - to keep sections separate (verses not always specified)
             s = "[]";
         }
-        return s.trim();
+        return s;
     }
 
     private String removeInline(String l) {
@@ -991,7 +1026,6 @@ class ChordProConvert {
                 newlyrics.append("\n");
 
         // Tidy up
-        // IV - Removed some replaces as the code changes (probably) make them redundant
         newlyrics = new StringBuilder(newlyrics.toString().replace("\n\n", "\n"));
         // Remove one space from the start of chord/lyric lines
         newlyrics = new StringBuilder(newlyrics.toString().replace("¬ ", "¬"));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -772,10 +772,14 @@ class ChordProConvert {
             replace(wm + " 2:", "[¬ 2¹").
             replace(wm + " 3:", "[¬ 3¹").
             replace(wm + " 4:", "[¬ 4¹").
+            replace(wm + " 5:", "[¬ 5¹").
+            replace(wm + " 6:", "[¬ 6¹").
             replace(wm + " 1", "[¬ 1¹").
             replace(wm + " 2", "[¬ 2¹").
             replace(wm + " 3", "[¬ 3¹").
             replace(wm + " 4", "[¬ 4¹").
+            replace(wm + " 5", "[¬ 5¹").
+            replace(wm + " 6", "[¬ 6¹").
             replace(wm, "[¬¹");
         // IV - And when uppercase
         wm = wm.toUpperCase();
@@ -784,15 +788,20 @@ class ChordProConvert {
             replace(wm + " 2:", "[¬ 2¹").
             replace(wm + " 3:", "[¬ 3¹").
             replace(wm + " 4:", "[¬ 4¹").
+            replace(wm + " 5:", "[¬ 5¹").
+            replace(wm + " 6:", "[¬ 6¹").
             replace(wm + " 1", "[¬ 1¹").
             replace(wm + " 2", "[¬ 2¹").
             replace(wm + " 3", "[¬ 3¹").
             replace(wm + " 4", "[¬ 4¹").
+            replace(wm + " 5", "[¬ 5¹").
+            replace(wm + " 6", "[¬ 6¹").
             replace(wm, "[¬¹");
 
         s = s.replace(";[","[").
             replace("#[","[").
             replace("; [", "[").
+            replace(" [","[").
             replace(";- [", "[");
 
         // IV - For a complete replace...

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
@@ -770,13 +770,15 @@ class ExportPreparer {
     }
 
     private String[] getHeadersAndFooters(String type) {
-        String[] starttag = new String[] {"", "", "Key:", "Tempo:", "Time:", "Copyright:", "CCLI: "};
+        // IV - With trailing space as onsong examples have this for human readability (it is probably not mandatory)
+        String[] starttag = new String[] {"", "", "Key: ", "Tempo: ", "Time: ", "Copyright: ", "CCLI: "};
         String endtag = "\n";
         StringBuilder header = new StringBuilder();
         StringBuilder footer = new StringBuilder();
 
         if (type.equals("choPro")) {
-            starttag = new String[] {"{title: ", "{artist: ", "{key: ", "{tempo: ", "{time: ", "{copyright: ", "{ccli:"};
+            // IV - No trailing space, this is optional in chorpro and we choose not to include
+            starttag = new String[] {"{title:", "{artist:", "{key:", "{tempo:", "{time:", "{copyright:", "{ccli:"};
             endtag = "}\n";
         }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OnSongConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OnSongConvert.java
@@ -66,9 +66,6 @@ class OnSongConvert {
         // Get rid of multilple line breaks (max of 3 together)
         lyrics = chordProConvert.getRidOfExtraLines(lyrics);
 
-        // Add spaces to beginnings of lines that aren't comments, chords or tags
-        lyrics = chordProConvert.addSpacesToLines(lyrics);
-
         // Get the filename and subfolder (if any) that the original song was in by parsing the uri
         oldSongFileName = chordProConvert.getOldSongFileName(uri);
         songSubFolder = chordProConvert.getSongFolderLocation(storageAccess, uri, oldSongFileName);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
@@ -367,7 +367,7 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, weblink);
 
         // If we are in songselect, trigger the download to keep the stats live
-        if (FullscreenActivity.whattodo.equals("songselect")) {
+        if (FullscreenActivity.whattodo.equals("songselect") && !(FullscreenActivity.phrasetosearchfor.startsWith("?"))) {
             try {
                 // Trigger the download of the pdf
                 webresults_WebView.loadUrl("javascript:document.getElementById('chordSheetDownloadButton').click()");
@@ -1153,7 +1153,7 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
             Log.d("FindNewSong", l);
         }
         int start = s.indexOf("<code class=\"cproSongKey\"");
-        int end = s.indexOf("</code></span>",start);
+        int end = s.indexOf("</code>",start);
         if (start>-1 && end>-1 && end>start) {
             // Fine tine the start
             int newstart = s.indexOf(">",start);
@@ -1175,7 +1175,8 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
             } else {
                 a = Html.fromHtml(a).toString();
             }
-            return "{artist:" + a + "}\n";
+            // IV - Replace use of | as separator with comma
+            return "{artist:" + a.replaceAll("\\Q |\\E",",") + "}\n";
         } else {
             return "";
         }
@@ -1194,7 +1195,8 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
         start = s.indexOf("<li>",start);
         int end = s.indexOf("</li>",start);
         if (start>-1 && end>-1 && end>start) {
-            return "{copyright:" + s.substring(start+4,end).trim() + "}\n";
+            // IV - Remove copyright and replace use of | as separator with ,
+            return "{copyright:" + s.substring(start+4,end).replace("©","").replaceAll("\\Q |\\E",",").trim() + "}\n";
         } else {
             return "";
         }
@@ -1228,6 +1230,7 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
             if (bits.length>1) {
                 String t = bits[1].replace("Time","");
                 t = t.replace("-","");
+                t = t.replace("&nbsp;"," ");
                 t = t.trim();
                 return "{time:" + t + "}\n";
             } else {
@@ -1237,43 +1240,49 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
         return "";
     }
     private String getLyricsSongSelectChordPro(String s) {
-        int start = s.indexOf("<pre class=\"cproSongBody\">");
-        int end = s.indexOf("</pre>",start);
-        if (start>-1 && end>-1 && end>start) {
-            String lyrics = s.substring(start+26,end);
+        // IV - Added handling of lyrics with with nore than one cproSongBody as split over pages
+        String lyrics = "";
+        while (s.contains("<pre class=\"cproSongBody\">")) {
+            int start = s.indexOf("<pre class=\"cproSongBody\">");
+            int end = s.indexOf("</pre>",start);
+            // IV - Overwrite so that next loop finds any further SongBody
+            s = s.replaceFirst("<pre class=\"cproSongBody\">", "<xxxxxxxxxxxxxxxxxxxxxxxx>");
+            s = s.replaceFirst("</pre>","<xxxx>");
 
-            // Fix the song section headers
-            while (lyrics.contains("<span class=\"cproSongSection\"><span class=\"cproComment\">")) {
-                start = lyrics.indexOf("<span class=\"cproSongSection\"><span class=\"cproComment\">");
-                end = lyrics.indexOf("</span>",start);
-                String sectiontext;
-                if (start>-1 && end>-1 && end>start) {
-                    sectiontext = lyrics.substring(start+56,end);
-                    lyrics = lyrics.replace("<span class=\"cproSongSection\"><span class=\"cproComment\">"+sectiontext+"</span>",sectiontext.trim()+":");
+            if (start>-1 && end>-1 && end>start) {
+                lyrics = lyrics + s.substring(start+26,end);
+
+                // Fix the song section headers
+                while (lyrics.contains("<span class=\"cproSongSection\"><span class=\"cproComment\">")) {
+                    start = lyrics.indexOf("<span class=\"cproSongSection\"><span class=\"cproComment\">");
+                    end = lyrics.indexOf("</span>",start);
+                    String sectiontext;
+                    if (start>-1 && end>-1 && end>start) {
+                        sectiontext = lyrics.substring(start+56,end);
+                        lyrics = lyrics.replace("<span class=\"cproSongSection\"><span class=\"cproComment\">" + sectiontext + "</span>", "#[" + sectiontext.trim() + "]");
+                    }
+                }
+
+                // Fix the chords
+                // Chords are found in a bit like this:
+                // <span class="chordWrapper"><code class="chord" data-chordname="D<sup>2</sup>">D<sup>2</sup></code>
+                // We want the last D<sup>2</sup> bit (<sup> removed later).
+
+                while (lyrics.contains("<span class=\"chordWrapper\"><code ")) {
+                    start = lyrics.indexOf("<span class=\"chordWrapper\"><code ");
+                    int newstart = lyrics.indexOf(">",start); // Move to bit before <
+                    newstart = lyrics.indexOf("\">",newstart)+2; // Go to bit after chordname="....">
+                    end = lyrics.indexOf("</code>",newstart);
+                    if (start>-1 && newstart>-1 && end>-1 && end>newstart) {
+                        String chordfound = lyrics.substring(newstart,end);
+                        String bittoremove = lyrics.substring(start,end+7);
+                        lyrics = lyrics.replace(bittoremove,"["+chordfound+"]");
+                    }
                 }
             }
-
-            // Fix the chords
-            // Chords are found in a bit like this:
-            // <span class="chordWrapper"><code class="chord" data-chordname="D<sup>2</sup>">D<sup>2</sup></code>
-            // We wand the last D<sup>2</sup> bit (<sup> removed later).
-
-            while (lyrics.contains("<span class=\"chordWrapper\"><code ")) {
-                start = lyrics.indexOf("<span class=\"chordWrapper\"><code ");
-                int newstart = lyrics.indexOf(">",start); // Move to bit before <
-                newstart = lyrics.indexOf("\">",newstart)+2; // Go to bit after chordname="....">
-                end = lyrics.indexOf("</code>",newstart);
-                if (start>-1 && newstart>-1 && end>-1 && end>newstart) {
-                    String chordfound = lyrics.substring(newstart,end);
-                    String bittoremove = lyrics.substring(start,end+7);
-                    lyrics = lyrics.replace(bittoremove,"["+chordfound+"]");
-                }
-            }
-
-            // Get rid of code that we don't need
-            return getRidOfRogueCode(lyrics);
         }
-        return "";
+        // Get rid of code that we don't need
+        return getRidOfRogueCode(lyrics);
     }
 
     private String extractSongSelectUsr(String s, String temptitle) {
@@ -1343,31 +1352,14 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
     }
 
     private String getRidOfRogueCode(String lyrics) {
-        // Get rid of lyric indications
-        lyrics = lyrics.replace("<span class=\"chordLyrics\">","");
-
-        // Get rid of the new line indications
-        lyrics = lyrics.replace("<span class=\"cproSongLine\">","");
-
-        // Get rid of the chord line only indications
-        lyrics = lyrics.replace("<span class=\"cproSongLine chordsOnly\">","");
-
-        // Get rid of directions indicators
-        lyrics = lyrics.replace("<span class=\"cproDirectionWrapper\">","");
-        lyrics = lyrics.replace("<span class=\"cproDirection\">","");
-
-        // Get rid of any remaining close spans
-        lyrics = lyrics.replace("</span>","");
-
-        // Get rid of any superscripts or subscripts
-        lyrics = lyrics.replace("<sup>","");
-        lyrics = lyrics.replace("</sup>","");
+        // Get rid of lyric indications (IV - etc. Remove any remaining <...>)
+        lyrics = lyrics.replaceAll("\\<.*?\\>","");
 
         // Fix accented characters into UTF
         lyrics = chordProConvert.parseHTML(lyrics);
 
-        // Finally, trim the lyrics
-        return lyrics.trim();
+        // Finally, end trim the lyrics
+        return (lyrics.replaceAll("\\s+$", ""));
     }
 
     private void setFileNameAndFolder() {
@@ -1686,18 +1678,19 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
         @Override
         protected void onPostExecute(String s) {
             if (getActivity()!=null) {
+                grabSongData_ProgressBar.setVisibility(View.INVISIBLE);
                 if (filecontents != null && !filecontents.equals("")) {
-                    //TODO
-                    // setFileNameAndFolder();
+                    // IV - Just in case we have not...
+                    if (newfileinfo_LinearLayout.getVisibility()!=View.VISIBLE) {
+                        setFileNameAndFolder();
+                    }
                 } else {
                     if (downloadcomplete) {
                         StaticVariables.myToastMessage = getActivity().getString(R.string.pdfonly);
                     } else {
                         StaticVariables.myToastMessage = getActivity().getResources().getText(R.string.chordpro_false).toString();
                     }
-
                     ShowToast.showToast(getActivity());
-                    grabSongData_ProgressBar.setVisibility(View.INVISIBLE);
                 }
             }
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -61,6 +61,7 @@ public class ProcessSong extends Activity {
         myLyrics = myLyrics.replace("&rdquo;", "'");
         myLyrics = myLyrics.replace("&rdquor;", "'");
         myLyrics = myLyrics.replace("&rsquo;", "'");
+        myLyrics = myLyrics.replace("&amp;rsquo;", "'");
         myLyrics = myLyrics.replace("&rdquor;", "'");
         myLyrics = myLyrics.replaceAll("\u0092", "'");
         myLyrics = myLyrics.replaceAll("\u0093", "'");

--- a/app/src/main/java/com/garethevans/church/opensongtablet/UsrConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/UsrConvert.java
@@ -39,9 +39,6 @@ class UsrConvert {
         // Get rid of multilple line breaks (max of 3 together)
         lyrics = chordProConvert.getRidOfExtraLines(lyrics);
 
-        // Add spaces to beginnings of lines that aren't comments, chords or tags
-        lyrics = chordProConvert.addSpacesToLines(lyrics);
-
         // Initialise the song tags
         songXML.initialiseSongTags();
 


### PR DESCRIPTION
Hello Gareth,

I have taken a look at SongSelect Extracts (a SongSelect free account lets you access pubic access domain chord sheets).

The proposed changes adopt the good principles of layout seen on SongSelect chord sheets for our OpenSong layout on converting a ChordPro song.  I have fixed (I think) issues with incorrect removal of leading spaces, multi-page SongSelect imports and others.

For a SongSelect extract the resulting OpenSong layout is close to the SongSelect chord sheet layout.  I suspect most users will use as-is.  For more advanced users it is a better starting point for adjusting for use with OpenSongApp projection etc - great.

Hopefully useful.

ADDED: I have added tweaks for 'Lyric only' (usr) SongSelect extract too!

Kind regards
Ian