### PR TITLE
BootUpCheck - further work

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/BootUpCheck.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/BootUpCheck.java
@@ -527,7 +527,7 @@ public class BootUpCheck extends AppCompatActivity {
             if (uriTree != null) {
                 DocumentFile df = storageAccess.documentFileFromRootUri(BootUpCheck.this, uriTree, uriTree.getPath());
                 if (df==null || !df.canWrite()) {
-                    progressText.setText(getString(R.string.currentstorage) + ": " + getString(R.string.notset));
+                    progressText.setText(getString(R.string.currentstorage) + ": " + getString(R.string.pleaseselect));
                 }
                 return df != null && df.canWrite();
             }
@@ -880,7 +880,7 @@ public class BootUpCheck extends AppCompatActivity {
                                 replace("¬/storage/emulated/legacy/" ,"/").
                                 replace("¬/storage/self/primary/"    ,"/");
                             if (where.startsWith("¬")) {
-                                // IV - Handle others paths as 'External'
+                                // IV - Handle other paths as 'External'
                                 where = where.substring(10);
                                 extra = extra + ", " + this.getResources().getString(R.string.storage_ext) + " " + where.substring(0, where.indexOf("/"));
                                 where = where.substring(where.indexOf("/"));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/BootUpCheck.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/BootUpCheck.java
@@ -333,8 +333,8 @@ public class BootUpCheck extends AppCompatActivity {
 
     private void showCurrentStorage(Uri u) {
         // This tries to make the uri more user readable!
-        // Declare variables
-        String text;
+        // IV - A text value of null can be set to force a valid selection
+        String text = null;
         // IV - Provides extra information on the folder
         String extra = "";
 
@@ -342,35 +342,37 @@ public class BootUpCheck extends AppCompatActivity {
         try {
             text = u.getPath();
             assert text != null;
-            // IV - When not an internal path (more patterns may be needed) indicate as external
-            if (!text.contains("/tree/primary")) { extra = this.getResources().getString(R.string.storage_ext); }
             // The  storage location getPath is likely something like /tree/primary:/document/primary:/OpenSong
             // This is due to the content using a document contract
-            text = "/" + text.substring(text.lastIndexOf(":") + 1);
-            text = text.replace("//", "/");
-            if (!text.endsWith("/" + storageAccess.appFolder)) {
-                text += "/" + storageAccess.appFolder;
+            // IV: Exclude raw storage
+            if (!text.startsWith("/tree/raw:") & text.contains(":")) {
+                // IV - When not an internal path (more patterns may be needed) indicate as external
+                if (!text.contains("/tree/primary")) { extra = this.getResources().getString(R.string.storage_ext); }
+                text = "/" + text.substring(text.lastIndexOf(":") + 1);
+                text = text.replace("//", "/");
+                if (!text.endsWith("/" + storageAccess.appFolder)) {
+                    text += "/" + storageAccess.appFolder;
+                }
+                // Decide if the user needs blocking as they have selected a subfolder of an OpenSong folder
+                if ((warningText!=null) && (text.contains("/OpenSong/"))) {
+                    uriTree = null;
+                    warningText.setVisibility(View.VISIBLE);
+                } else {
+                    warningText.setVisibility(View.GONE);
+                }
+            } else {
+                uriTree = null;
             }
         } catch (Exception e) {
             e.printStackTrace();
-            if (uriTreeHome == null) {
-                text = getString(R.string.notset);
-            } else {
-                text = "" + uriTreeHome;
-            }
+            uriTree = null;
         }
 
-        // Decide if the user needs blocking as  they have selected a subfolder of an OpenSong folder
-        if (warningText!=null) {
-            if (text.contains("/OpenSong/")) {
-                // IV - Force 'Not set'
-                uriTree = null;
-                text = getString(R.string.notset);
-                saveUriLocation();
-                warningText.setVisibility(View.VISIBLE);
-            } else {
-                warningText.setVisibility(View.GONE);
-            }
+        // IV - If we do not have a valid uri force 'Please select'
+        if (uriTree == null) {
+            uriTreeHome = null;
+            text = getString(R.string.pleaseselect);
+            saveUriLocation();
         }
 
         if (progressText!=null) {
@@ -417,7 +419,8 @@ public class BootUpCheck extends AppCompatActivity {
                     intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION |
                             Intent.FLAG_GRANT_READ_URI_PERMISSION |
                             Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                    //intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+                    // IV - 'Commented in' this extra to try to always show internal and sd card storage
+                    intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
                     //intent.putExtra("android.content.extra.FANCY", true);
                     //intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
                     intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI,uriTree);
@@ -524,7 +527,7 @@ public class BootUpCheck extends AppCompatActivity {
             if (uriTree != null) {
                 DocumentFile df = storageAccess.documentFileFromRootUri(BootUpCheck.this, uriTree, uriTree.getPath());
                 if (df==null || !df.canWrite()) {
-                    progressText.setText(R.string.notset);
+                    progressText.setText(getString(R.string.currentstorage) + ": " + getString(R.string.notset));
                 }
                 return df != null && df.canWrite();
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,7 +403,7 @@
     <string name="next">Next</string>
     <string name="no">No</string>
     <string name="nodisplays">No external displays connected.  Please connect to a secondary display using an HDMI output or MiraCast compatible wireless display.</string>
-    <string name="nofound">No previous installations found.</string>
+    <string name="nofound">No previous folder found.  Use the red button to choose a location.</string>
     <string name="not_allowed">This function is not allowed for this item</string>
     <string name="note">Note</string>
     <string name="nothighenoughapi">You need a newer version of Android for this!</string>
@@ -545,7 +545,7 @@
     <string name="storage_check">Checking storage</string>
     <string name="storage_choose">Manage storage</string>
     <string name="storage_ext">External storage</string>
-    <string name="storage_help">Please choose the location for your \'OpenSong\' folder.  This is the default storage location for OpenSong files.  We recommend using internal storage.  You can change this at any time from the Options menu.\n\nFor an update or re-install:\nIf the current location is not set, use the yellow button below to find your \'OpenSong\' folder.</string>
+    <string name="storage_help">Please choose the location for your \'OpenSong\' folder.  This is the default storage location for OpenSong files.  You can change this at any time from the Options menu.\n\nFor an update or re-install:\nYou can use the yellow button below to find any previous \'OpenSong\' folder.\n\nWhen selecting a location:\nList storage using the menu (you may need to change settings to show all storage).\nSELECT ONLY INTERNAL OR SD CARD storage, these have details below their name.\nInternal storage is recommended.  This may list as device storage or with your devices\'s name.</string>
     <string name="storage_notwritable">Unable to use</string>
     <string name="storage_rationale">Access to your storage is required to read and write songs and sets.</string>
     <string name="subscription">(Subscription required)</string>


### PR DESCRIPTION
Hello Gareth,

Here is a further take on BootUpCheck.  This tries to ensure only internal or sd card storage can be selected - not the dreaded Downloads.  This will mean a user using 'Downloads' will need to re-select!

It provides advice on selecting - it is hard to come up with words that are useful for all Android version!

Put up for discussion / refinement!

Kind regards
Ian