### PR TITLE
Nearby tweaks

### DIFF
--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -10,8 +10,8 @@
     {
       "type": "SINGLE",
       "filters": [],
-      "versionCode": 190,
-      "versionName": "5.3.0",
+      "versionCode": 191,
+      "versionName": "5.3.1",
       "outputFile": "app-release.apk"
     }
   ]

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -189,19 +189,24 @@ public class NearbyConnections implements NearbyInterface {
                 if (connectedDeviceIds.contains(connectionInfo.getEndpointName())) {
                     delayAcceptConnection(endpointId,connectionInfo);
                 } else {
-                    new AlertDialog.Builder(context)
-                            .setTitle(context.getResources().getString(R.string.accept_connection) + " " + connectionInfo.getEndpointName())
-                            .setMessage(context.getResources().getString(R.string.accept_code) + " " + connectionInfo.getAuthenticationToken())
-                            .setPositiveButton(
-                                    context.getResources().getString(R.string.ok),
-                                    (DialogInterface dialog, int which) -> delayAcceptConnection(endpointId, connectionInfo))
-                            .setNegativeButton(
-                                    context.getResources().getString(R.string.cancel),
-                                    (DialogInterface dialog, int which) ->
-                                            // The user canceled, so we should reject the connection.
-                                            Nearby.getConnectionsClient(context).rejectConnection(endpointId))
-                            .setIcon(android.R.drawable.ic_dialog_alert)
-                            .show();
+                    if (StaticVariables.whichOptionMenu.equals("CONNECT")) {
+                        new AlertDialog.Builder(context)
+                                .setTitle(context.getResources().getString(R.string.accept_connection) + " " + connectionInfo.getEndpointName())
+                                .setMessage(context.getResources().getString(R.string.accept_code) + " " + connectionInfo.getAuthenticationToken())
+                                .setPositiveButton(
+                                        context.getResources().getString(R.string.ok),
+                                        (DialogInterface dialog, int which) -> delayAcceptConnection(endpointId, connectionInfo))
+                                .setNegativeButton(
+                                        context.getResources().getString(R.string.cancel),
+                                        (DialogInterface dialog, int which) ->
+                                                // The user canceled, so we should reject the connection.
+                                                Nearby.getConnectionsClient(context).rejectConnection(endpointId))
+                                .setIcon(android.R.drawable.ic_dialog_alert)
+                                .show();
+                    } else {
+                        // The user is not accepting new connections, so we should reject the connection.
+                        Nearby.getConnectionsClient(context).rejectConnection(endpointId);
+                    }
                 }
             }
 
@@ -285,6 +290,11 @@ public class NearbyConnections implements NearbyInterface {
             public void onEndpointLost(@NonNull String endpointId) {
                 Log.d("NearbyConnections","onEndPointlost");
                 updateConnectionLog(context.getResources().getString(R.string.connections_disconnect) + " " + getDeviceNameFromId(endpointId));
+                // Try to connect again after 2 seconds
+                if (!StaticVariables.isHost) {
+                    Handler h = new Handler();
+                    h.postDelayed(() -> startDiscovery(), 2000);
+                }
             }
         };
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -248,13 +248,13 @@ public class NearbyConnections implements NearbyInterface {
                 String deviceName = getDeviceNameFromId(endpointId);
                 connectedEndPointsNames.remove(endpointId+"__"+deviceName);
                 updateConnectionLog(context.getResources().getString(R.string.connections_disconnect) + " " + deviceName);
+                // Check if we have valid connections
+                StaticVariables.isConnected = stillValidConnections();
                 // Try to connect again after 2 seconds
                 if (!StaticVariables.isHost) {
                     Handler h = new Handler();
                     h.postDelayed(() -> startDiscovery(), 2000);
                 }
-                // Check if we have valid connections
-                StaticVariables.isConnected = stillValidConnections();
             }
         };
     }
@@ -292,6 +292,8 @@ public class NearbyConnections implements NearbyInterface {
             public void onEndpointLost(@NonNull String endpointId) {
                 Log.d("NearbyConnections","onEndPointlost");
                 updateConnectionLog(context.getResources().getString(R.string.connections_disconnect) + " " + getDeviceNameFromId(endpointId));
+                // Check if we have valid connections
+                StaticVariables.isConnected = stillValidConnections();
                 // Try to connect again after 2 seconds
                 if (!StaticVariables.isHost) {
                     Handler h = new Handler();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -3308,15 +3308,12 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
 
                     // Now that we have generated the song to send to a guest device, decide if we should remove chords, comments, etc.
                     for (int i = 0; i < StaticVariables.songSections.length; i++) {
-                        StaticVariables.songSections[i] = processSong.removeUnderScores(PresenterMode.this,
-                                preferences, StaticVariables.songSections[i]);
                         if (!preferences.getMyPreferenceBoolean(PresenterMode.this,"presoShowChords",false)) {
                             StaticVariables.songSections[i] = processSong.removeChordLines(StaticVariables.songSections[i]);
                         }
                         if (!StaticVariables.isHost || !StaticVariables.isConnected || !StaticVariables.usingNearby) {
                             StaticVariables.songSections[i] = processSong.removeCommentLines(StaticVariables.songSections[i]);
                         }
-
                         StaticVariables.songSections[i] = processSong.removeUnderScores(PresenterMode.this,
                                 preferences, StaticVariables.songSections[i]);
                     }

--- a/app/src/main/res/layout/boot_up_check.xml
+++ b/app/src/main/res/layout/boot_up_check.xml
@@ -108,6 +108,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
@@ -125,12 +126,10 @@
 
                     <TextView
                         android:id="@+id/progressText"
-                        android:layout_marginTop="8dp"
-                        android:layout_marginBottom="10dp"
+                        style="@style/MyHeadingText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        style="@style/MyHeadingText"/>
+                        android:layout_gravity="center_vertical" />
                 </LinearLayout>
 
 
@@ -153,7 +152,7 @@
 
                     <Button
                         android:id="@+id/chooseStorageButton"
-                        android:layout_width="250dp"
+                        android:layout_width="170dp"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
                         android:background="@drawable/red_button"
@@ -179,7 +178,7 @@
                     android:id="@+id/previousStorageButton"
                     android:textSize="14sp"
                     android:background="@drawable/yellow_button"
-                    android:layout_width="250dp"
+                    android:layout_width="170dp"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
                     android:layout_margin="8dp"


### PR DESCRIPTION
Hello Gareth,

Trying to help nearby behaviour with a focus on preventing a user being disturbed when connections are made...

1. Host must be intentionally in 'Connect Devices' to respond to new connections.
Aims - No prompts appearing on screen when the host user is performing.  Intentional management of new connections.

2. Client is not interrupted when another client connects to the host.  The client will receive the 'general' open song request but ignore when the current song is the same.
Aim: To support another clients re-connection during performance, that client will be known by and silently connected by the host.  The use of the app on existing clients should not be disturbed.

Please consider. Getting there!

Kind regards
Ian V

p.s. Some other minor tweaks