### PR TITLE
Nearby and HDMI/Second screen adjustments 

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/FullscreenActivity.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/FullscreenActivity.java
@@ -92,6 +92,10 @@ public class FullscreenActivity extends AppCompatActivity {
     public static int whichPad = 0;
 
     public static boolean alreadyloading = false;
+    // IV - Some mode oncreate actions are only needed once
+    public static boolean doonetimeactions = true;
+    // IV - Persist knowledge of a current hdmi session
+    public static PresentationServiceHDMI hdmi;
 
     // Flag to indicate that Android Beam is available
     public static final boolean mAndroidBeamAvailable  = false;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -343,6 +343,14 @@ public class NearbyConnections implements NearbyInterface {
                                         if (((ApiException) e).getStatusCode() == ConnectionsStatusCodes.STATUS_ALREADY_CONNECTED_TO_ENDPOINT) {
                                             StaticVariables.isConnected = true;
                                             updateConnectionLog(context.getResources().getString(R.string.connections_connected) + " " + getDeviceNameFromId(endpointId));
+                                            // IV - Already connected so replay last incoming song
+                                            if (incomingPrevious != null) {
+                                                String incoming = incomingPrevious;
+                                                incomingPrevious = null;
+                                                payloadOpenSong(incoming);
+                                            }
+                                            // We can stop discovery now
+                                            stopDiscovery();
                                         } else {
                                             // Nearby Connections failed to request the connection.
                                             updateConnectionLog(context.getResources().getString(R.string.connections_failure) + " " + getDeviceNameFromId(endpointId));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -1881,8 +1881,17 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         receiveHostFiles.setOnCheckedChangeListener((view,isChecked) -> {
             StaticVariables.receiveHostFiles = isChecked;
             keepHostFiles.setEnabled(isChecked);
+            // IV - Re-connect to apply setting
+            Handler h = new Handler();
+            h.postDelayed(() -> connectionSearch.performClick(),2000);
         });
-        keepHostFiles.setOnCheckedChangeListener((view,isChecked) -> StaticVariables.keepHostFiles = isChecked);
+
+        keepHostFiles.setOnCheckedChangeListener((view,isChecked) -> {
+            StaticVariables.keepHostFiles = isChecked;
+            // IV - Re-connect to apply setting
+            Handler h = new Handler();
+            h.postDelayed(() -> connectionSearch.performClick(),2000);
+        });
 
         deviceName.setOnClickListener(view -> {
             FullscreenActivity.whattodo = "connect_name";
@@ -1985,27 +1994,6 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         setTextButtons(modeStageButton,c.getString(R.string.stagemode));
         setTextButtons(modePresentationButton,c.getString(R.string.presentermode));
 
-        // Set a tick next to the current mode
-        switch (StaticVariables.whichMode) {
-            case "Performance":
-                modePerformanceButton.setEnabled(false);
-                modeStageButton.setEnabled(true);
-                modePresentationButton.setEnabled(true);
-                break;
-
-            case "Stage":
-                modePerformanceButton.setEnabled(true);
-                modeStageButton.setEnabled(false);
-                modePresentationButton.setEnabled(true);
-                break;
-
-            case "Presentation":
-                modePerformanceButton.setEnabled(true);
-                modeStageButton.setEnabled(true);
-                modePresentationButton.setEnabled(false);
-                break;
-
-        }
         // Set the button listeners
         menuUp.setOnClickListener(view -> {
             StaticVariables.whichOptionMenu = "MAIN";
@@ -2014,51 +2002,44 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
             }
         });
         modePerformanceButton.setOnClickListener(view -> {
-            if (!StaticVariables.whichMode.equals("Performance")) {
-                // Switch to performance mode
-                StaticVariables.whichMode = "Performance";
-                preferences.setMyPreferenceString(c,"whichMode","Performance");
-                Intent performmode = new Intent();
-                performmode.setClass(c, StageMode.class);
-                if (mListener!=null) {
-                    mListener.closeMyDrawers("option");
-                    mListener.callIntent("activity", performmode);
-                }
-            }
+            modeOptionListenerActivity(c, preferences, "Performance");
         });
         modeStageButton.setOnClickListener(view -> {
-            if (!StaticVariables.whichMode.equals("Stage")) {
-                // Switch to stage mode
-                StaticVariables.whichMode = "Stage";
-                preferences.setMyPreferenceString(c,"whichMode","Stage");
-                Intent stagemode = new Intent();
-                stagemode.setClass(c, StageMode.class);
-                if (mListener!=null) {
-                    mListener.closeMyDrawers("option");
-                    mListener.callIntent("activity", stagemode);
-                }
-            }
+            modeOptionListenerActivity(c, preferences, "Stage");
         });
         modePresentationButton.setOnClickListener(view -> {
-            if (!StaticVariables.whichMode.equals("Presentation")) {
-                // Switch to presentation mode
-                StaticVariables.whichMode = "Presentation";
-                preferences.setMyPreferenceString(c,"whichMode","Presentation");
-                Intent presentmode = new Intent();
-                presentmode.setClass(c, PresenterMode.class);
-                if (mListener!=null) {
-                    mListener.closeMyDrawers("option");
-                    mListener.callIntent("activity", presentmode);
-                }
-            }
+            modeOptionListenerActivity(c, preferences, "Presentation");
         });
-
         closeOptionsFAB.setOnClickListener(view -> {
             if (mListener!=null) {
                 mListener.closeMyDrawers("option");
             }
         });
+   }
 
+    private static void modeOptionListenerActivity(final Context c, final Preferences preferences, final String targetMode) {
+        // IV - Already in the selected mode, just close drawer
+        if (StaticVariables.whichMode.equals(targetMode)) {
+            if (mListener!=null) {
+                mListener.closeMyDrawers("option");
+            }
+        } else {
+            StaticVariables.whichMode = targetMode;
+            preferences.setMyPreferenceString(c,"whichMode", StaticVariables.whichMode);
+            Intent appmmode = new Intent();
+            if (StaticVariables.whichMode.equals("Presentation")) {
+                appmmode.setClass(c, PresenterMode.class);
+            } else {
+                appmmode.setClass(c, StageMode.class);
+            }
+            if (mListener != null) {
+                // IV - Go to new mode
+                mListener.callIntent("activity", appmmode);
+                // IV - Kick HDMI after a delay
+                Handler h = new Handler();
+                h.postDelayed(() -> mListener.connectHDMI(), 5000);
+            }
+        }
     }
 
     private static void autoscrollOptionListener(View v, final Context c, final Preferences preferences) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
@@ -58,6 +58,7 @@ public class PopUpLayoutFragment extends DialogFragment {
     private LinearLayout group_maxfontsize;
     private LinearLayout group_manualfontsize;
     private LinearLayout blockShadowAlphaLayout;
+    private TextView blockShadowAlphaText;
     private SeekBar setMaxFontSizeProgressBar, setFontSizeProgressBar, presoAlphaProgressBar,
             setXMarginProgressBar, setYMarginProgressBar, presoTitleSizeSeekBar,
             presoAuthorSizeSeekBar, presoCopyrightSizeSeekBar, setRotationProgressBar,
@@ -65,7 +66,8 @@ public class PopUpLayoutFragment extends DialogFragment {
     private TextView maxfontSizePreview;
     private TextView fontSizePreview;
     private TextView presoAlphaText;
-    private TextView lyrics_title_align;
+    private LinearLayout lyrics_title_align;
+    private LinearLayout group_songinfofontsizes;
     private TextView presoTransitionTimeTextView;
     private TextView rotationTextView;
     private FloatingActionButton lyrics_left_align, lyrics_center_align, lyrics_right_align,
@@ -140,6 +142,7 @@ public class PopUpLayoutFragment extends DialogFragment {
         blockShadow = V.findViewById(R.id.blockShadow);
         blockShadowAlphaLayout = V.findViewById(R.id.blockShadowAlphaLayout);
         blockShadowAlpha = V.findViewById(R.id.blockShadowAlpha);
+        blockShadowAlphaText = V.findViewById(R.id.blockShadowAlphaText);
         toggleChordsButton = V.findViewById(R.id.toggleChordsButton);
         boldTextButton = V.findViewById(R.id.boldTextButton);
         toggleAutoScaleButton = V.findViewById(R.id.toggleAutoScaleButton);
@@ -147,6 +150,7 @@ public class PopUpLayoutFragment extends DialogFragment {
         setMaxFontSizeProgressBar = V.findViewById(R.id.setMaxFontSizeProgressBar);
         maxfontSizePreview = V.findViewById(R.id.maxfontSizePreview);
         group_manualfontsize = V.findViewById(R.id.group_manualfontsize);
+        group_songinfofontsizes = V.findViewById(R.id.group_songinfofontsizes);
         setFontSizeProgressBar = V.findViewById(R.id.setFontSizeProgressBar);
         fontSizePreview = V.findViewById(R.id.fontSizePreview);
         lyrics_title_align = V.findViewById(R.id.lyrics_title_align);
@@ -179,10 +183,18 @@ public class PopUpLayoutFragment extends DialogFragment {
         setXMarginProgressBar = V.findViewById(R.id.setXMarginProgressBar);
         setYMarginProgressBar = V.findViewById(R.id.setYMarginProgressBar);
         TextView modes_TextView = V.findViewById(R.id.modes_TextView);
-        String s = getString(R.string.performancemode) + " " + getString(R.string.separator) + " " +
-                getString(R.string.stagemode) +" " + getString(R.string.separator) + " " +
-                getString (R.string.presentermode);
-        modes_TextView.setText(s);
+        switch (StaticVariables.whichMode) {
+            case "Performance":
+            default:
+                modes_TextView.setText(getString(R.string.performancemode));
+                break;
+            case "Stage":
+                modes_TextView.setText(getString(R.string.stagemode));
+                break;
+            case "Presentation":
+                modes_TextView.setText(getString(R.string.presentermode));
+                break;
+        }
         rotationTextView = V.findViewById(R.id.rotationTextView);
         setRotationProgressBar = V.findViewById(R.id.setRotationProgressBar);
     }
@@ -192,15 +204,36 @@ public class PopUpLayoutFragment extends DialogFragment {
         blockShadow.setChecked(preferences.getMyPreferenceBoolean(getContext(),"blockShadow",false));
         setBlockAlphaVisibility();
         blockShadowAlpha.setMax(100);
-        blockShadowAlpha.setProgress((int)(preferences.getMyPreferenceFloat(getContext(),"blockShadowAlpha",0.7f)*100));
+        float alphaval = preferences.getMyPreferenceFloat(getContext(),"blockShadowAlpha",0.7f);
+        blockShadowAlpha.setProgress((int)(alphaval*100.0f));
+        String newtext = (int) (alphaval * 100.0f) + " %";
+        blockShadowAlphaText.setText(newtext);
         toggleChordsButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoShowChords",false));
-        toggleAutoScaleButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoAutoScale",true));
-        boldTextButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoLyricsBold",false));
+        if (StaticVariables.whichMode.equals("Presentation")) {
+            toggleAutoScaleButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoAutoScale",true));
+            showorhideView(group_maxfontsize, toggleAutoScaleButton.isChecked());
+            showorhideView(group_manualfontsize, !toggleAutoScaleButton.isChecked());
+            boldTextButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoLyricsBold",false));
+        } else {
+            toggleAutoScaleButton.setVisibility(View.GONE);
+            showorhideView(group_maxfontsize, true);
+            showorhideView(group_manualfontsize, false);
+            boldTextButton.setVisibility(View.GONE);
+            group_songinfofontsizes.setVisibility(View.GONE);
+        }
         setMaxFontSizeProgressBar.setMax(70);
-        setMaxFontSizeProgressBar.setProgress((int)preferences.getMyPreferenceFloat(getContext(),"fontSizePresoMax",40.0f) - 4);
+        int progress = (int)preferences.getMyPreferenceFloat(getContext(),"fontSizePresoMax",40.0f) - 4;
+        setMaxFontSizeProgressBar.setProgress(progress - 4);
+        newtext = (progress + 4) + " sp";
+        maxfontSizePreview.setText(newtext);
+        maxfontSizePreview.setTextSize(progress + 4);
         maxfontSizePreview.setTypeface(StaticVariables.typefacePreso);
         setFontSizeProgressBar.setMax(70);
-        setFontSizeProgressBar.setProgress((int)preferences.getMyPreferenceFloat(getContext(),"fontSizePreso",14.0f) - 4);
+        progress = (int)preferences.getMyPreferenceFloat(getContext(),"fontSizePreso",14.0f) - 4;
+        setFontSizeProgressBar.setProgress(progress - 4);
+        newtext = (progress + 4) + " sp";
+        fontSizePreview.setText(newtext);
+        fontSizePreview.setTextSize(progress + 4);
         fontSizePreview.setTypeface(StaticVariables.typefacePreso);
         setUpAlignmentButtons();
         presoTitleSizeSeekBar.setMax(32);
@@ -211,15 +244,18 @@ public class PopUpLayoutFragment extends DialogFragment {
         presoAuthorSizeSeekBar.setProgress((int)preferences.getMyPreferenceFloat(getContext(),"presoAuthorTextSize", 12.0f));
         presoCopyrightSizeSeekBar.setProgress((int)preferences.getMyPreferenceFloat(getContext(),"presoCopyrightTextSize", 12.0f));
         presoAlertSizeSeekBar.setProgress((int)preferences.getMyPreferenceFloat(getContext(),"presoAlertTextSize", 12.0f));
-        float alphaval = preferences.getMyPreferenceFloat(getContext(),"presoBackgroundAlpha",0.8f);
+        alphaval = preferences.getMyPreferenceFloat(getContext(),"presoBackgroundAlpha",0.8f);
         presoAlphaProgressBar.setProgress((int)(alphaval*100.0f));
-        String newtext = (int) (alphaval * 100.0f) + " %";
+        newtext = (int) (alphaval * 100.0f) + " %";
         presoAlphaText.setText(newtext);
         presoTransitionTimeSeekBar.setMax(23);
         presoTransitionTimeSeekBar.setProgress(timeToSeekBarProgress());
         presoTransitionTimeTextView.setText(SeekBarProgressToText());
         setupPreviews();
-        setCheckBoxes();
+        // IV - Only Presentation mode starts with a background
+        if (StaticVariables.whichMode.equals("Presentation")) {
+            setCheckBoxes();
+        }
         setXMarginProgressBar.setMax(150);
         setYMarginProgressBar.setMax(150);
         setXMarginProgressBar.setProgress(preferences.getMyPreferenceInt(getContext(),"presoXMargin",20));
@@ -289,7 +325,10 @@ public class PopUpLayoutFragment extends DialogFragment {
         });
         blockShadowAlpha.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
-            public void onProgressChanged(SeekBar seekBar, int i, boolean b) { }
+            public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
+                String update = i + " %";
+                blockShadowAlphaText.setText(update);
+            }
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) { }
@@ -509,67 +548,57 @@ public class PopUpLayoutFragment extends DialogFragment {
     }
 
     private void setUpAlignmentButtons() {
-        int lyralign = preferences.getMyPreferenceInt(getContext(),"presoLyricsAlign",Gravity.CENTER_HORIZONTAL);
-        int lyrvalign = preferences.getMyPreferenceInt(getContext(),"presoLyricsVAlign",Gravity.CENTER_VERTICAL);
-        int infalign = preferences.getMyPreferenceInt(getContext(),"presoInfoAlign",Gravity.END);
-        if (lyralign == Gravity.START) {
-            lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        } else if (lyralign == Gravity.END) {
-            lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-        } else { // CENTER_HORIZONTAL
-            lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        }
-        if (lyrvalign == Gravity.TOP) {
-            lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        } else if (lyrvalign == Gravity.BOTTOM) {
-            lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-        } else { // CENTER_VERTICAL
-            lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        }
-        if (infalign == Gravity.START) {
-            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        } else if (infalign == Gravity.END) {
-            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-        } else { // CENTER_HORIZONTAL
-            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xffff0000));
-            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-        }
 
-        // If chords are being show, hide the lyrics align, otherwise it is ok to show
-        boolean vis = true;
-        if (preferences.getMyPreferenceBoolean(getContext(),"presoShowChords",false)) {
-            vis = false;
-        }
-        lyrics_left_align.setEnabled(vis);
-        lyrics_right_align.setEnabled(vis);
-        lyrics_center_align.setEnabled(vis);
+        // IV  - Only used for specific situations
+        if ((StaticVariables.whichMode.equals("Stage") && !(preferences.getMyPreferenceBoolean(getContext(),"presoShowChords",false))) ||
+                StaticVariables.whichMode.equals("Presentation")) {
 
-        setViewVis(lyrics_title_align,vis);
-    }
+            int lyralign = preferences.getMyPreferenceInt(getContext(), "presoLyricsAlign", Gravity.CENTER_HORIZONTAL);
+            int lyrvalign = preferences.getMyPreferenceInt(getContext(), "presoLyricsVAlign", Gravity.CENTER_VERTICAL);
+            int infalign = preferences.getMyPreferenceInt(getContext(), "presoInfoAlign", Gravity.END);
 
-
-    private void setViewVis(View v, boolean vis) {
-        if (vis) {
-            v.setVisibility(View.VISIBLE);
+            if (lyralign == Gravity.START) {
+                lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            } else if (lyralign == Gravity.END) {
+                lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+            } else { // CENTER_HORIZONTAL
+                lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                lyrics_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            }
+            if (lyrvalign == Gravity.TOP) {
+                lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            } else if (lyrvalign == Gravity.BOTTOM) {
+                lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+            } else { // CENTER_VERTICAL
+                lyrics_top_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            }
+            if (infalign == Gravity.START) {
+                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            } else if (infalign == Gravity.END) {
+                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+            } else { // CENTER_HORIZONTAL
+                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            }
+            lyrics_title_align.setVisibility(View.VISIBLE);
         } else {
-            v.setVisibility(View.GONE);
+            lyrics_title_align.setVisibility(View.GONE);
         }
     }
 
@@ -578,6 +607,7 @@ public class PopUpLayoutFragment extends DialogFragment {
         switch (preferences.getMyPreferenceString(getContext(),"backgroundToUse","img1")) {
             case "img1":
                 image1CheckBox.setChecked(true);
+                image1CheckBox.setTextColor(0xff444488);
                 image2CheckBox.setChecked(false);
                 video1CheckBox.setChecked(false);
                 video2CheckBox.setChecked(false);
@@ -585,6 +615,7 @@ public class PopUpLayoutFragment extends DialogFragment {
             case "img2":
                 image1CheckBox.setChecked(false);
                 image2CheckBox.setChecked(true);
+                image2CheckBox.setTextColor(0xff444488);
                 video1CheckBox.setChecked(false);
                 video2CheckBox.setChecked(false);
                 break;
@@ -592,6 +623,7 @@ public class PopUpLayoutFragment extends DialogFragment {
                 image1CheckBox.setChecked(false);
                 image2CheckBox.setChecked(false);
                 video1CheckBox.setChecked(true);
+                video1CheckBox.setTextColor(0xff444488);
                 video2CheckBox.setChecked(false);
                 break;
             case "vid2":
@@ -599,6 +631,7 @@ public class PopUpLayoutFragment extends DialogFragment {
                 image2CheckBox.setChecked(false);
                 video1CheckBox.setChecked(false);
                 video2CheckBox.setChecked(true);
+                video2CheckBox.setTextColor(0xff444488);
                 break;
         }
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresentationCommon.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresentationCommon.java
@@ -719,8 +719,8 @@ class PresentationCommon {
         if (!StaticVariables.mAuthor.equals("")) {
             new_title = new_title + "\n" + StaticVariables.mAuthor;
         }
-        // IV - If we have something then cross fade in
-        if (!old_title.equals(new_title)) {
+        // IV - If we have something or are not yet displaying, cross fade in
+        if (!old_title.equals(new_title) ||  songinfo_TextView.getAlpha() == 0.0f) {
             CustomAnimations.faderAnimation(bottom_infobar,preferences.getMyPreferenceInt(c,"presoTransitionTime",800),false);
             // IV - Now run the next bit post delayed (to wait for the animate out)
             if (!(FullscreenActivity.isImage || FullscreenActivity.isImageSlide || FullscreenActivity.isPDF) && (!new_title.isEmpty())) {

--- a/app/src/main/res/layout/popup_layout.xml
+++ b/app/src/main/res/layout/popup_layout.xml
@@ -12,12 +12,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true">
-
         <include layout="@layout/popup_dialogtitle" />
     </FrameLayout>
 
     <ScrollView
-        android:id="@+id/scrollView4"
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/myTitle">
@@ -27,462 +26,170 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/modes_TextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:background="@drawable/section_box"
+                android:layout_marginStart="8dp"
+                android:text="@string/performancemode" />
+
+            <TextView
+                style="@style/MyHeadingText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/crossfade_time" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <SeekBar
+                android:id="@+id/presoTransitionTimeSeekBar"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:layout_weight="1"
+                android:background="@drawable/apptheme_scrubber_primary_holo"
+                android:max="100"
+                android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
+
+            <TextView
+                android:id="@+id/presoTransitionTimeTextView"
+                style="@style/MyInfoText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/zerotime" />
+        </LinearLayout>
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleAutoScaleButton"
+                android:textColor="#ff0"
+                android:textOff="@string/off"
+                android:textOn="@string/on"
+                style="@style/MyTextSwitch"
+                app:showText="true"
+                app:switchTextAppearance="@style/MyInfoText"
+                app:thumbTextPadding="4dp"
+                app:thumbTint="#444488"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/autoscale_toggle" />
+
+            <LinearLayout
+                android:id="@+id/group_maxfontsize"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/modes_TextView"
                     style="@style/MyHeadingText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/performancemode" />
-
-                <LinearLayout
-                    android:id="@+id/group_margins"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginEnd="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/rotate_display" />
-
-                    <SeekBar
-                        android:id="@+id/setRotationProgressBar"
-                        style="?android:attr/progressBarStyleHorizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        android:id="@+id/rotationTextView"
-                        style="@style/MyInfoText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:gravity="center_horizontal"
-                        android:text="@string/zerotime" />
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/setxmargins" />
-
-                    <SeekBar
-                        android:id="@+id/setXMarginProgressBar"
-                        style="?android:attr/progressBarStyleHorizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/setymargins" />
-
-                    <SeekBar
-                        android:id="@+id/setYMarginProgressBar"
-                        style="?android:attr/progressBarStyleHorizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="24dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                </LinearLayout>
-
-                <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/toggleChordsButton"
-                    style="@style/MyWhiteHeadingText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="24dp"
-                    android:text="@string/showchords"
-                    android:theme="@style/SwitchStyle" />
-
-                <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/boldTextButton"
-                    style="@style/MyWhiteHeadingText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="24dp"
-                    android:text="@string/bold_text"
-                    android:theme="@style/SwitchStyle" />
-
-                <TextView
-                    style="@style/MyWhiteHeadingText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="0dp"
-                    android:text="@string/crossfade_time" />
+                    android:layout_margin="8dp"
+                    android:text="@string/maxfontsize" />
 
                 <SeekBar
-                    android:id="@+id/presoTransitionTimeSeekBar"
-                    style="?android:attr/progressBarStyleHorizontal"
+                    android:id="@+id/setMaxFontSizeProgressBar"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="0dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="0dp"
+                    android:layout_margin="8dp"
                     android:background="@drawable/apptheme_scrubber_primary_holo"
                     android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
                     android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
 
                 <TextView
-                    android:id="@+id/presoTransitionTimeTextView"
+                    android:id="@+id/maxfontSizePreview"
                     style="@style/MyInfoText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="0dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="12dp"
-                    android:gravity="center_horizontal"
-                    android:text="@string/zerotime" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="100dp"
+                    android:layout_gravity="center_horizontal|top" />
 
             </LinearLayout>
 
-
             <LinearLayout
+                android:id="@+id/group_manualfontsize"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/section_box"
                 android:orientation="vertical">
 
                 <TextView
                     style="@style/MyHeadingText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/presentermode" />
-
-                <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/toggleAutoScaleButton"
-                    style="@style/MyWhiteHeadingText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="12dp"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginRight="12dp"
-                    android:layout_marginBottom="24dp"
-                    android:text="@string/autoscale_toggle"
-                    android:theme="@style/SwitchStyle" />
+                    android:layout_margin="8dp"
+                    android:text="@string/choose_fontsize" />
 
                 <LinearLayout
-                    android:id="@+id/group_maxfontsize"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                <SeekBar
+                    android:id="@+id/setFontSizeProgressBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
+
+                <TextView
+                    android:id="@+id/fontSizePreview"
+                    style="@style/MyInfoText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="100dp"
+                    android:layout_gravity="center_horizontal|top" />
+
+            </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/blockShadowAlphaLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+            </LinearLayout>
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleChordsButton"
+                android:textColor="#ff0"
+                android:textOff="@string/off"
+                android:textOn="@string/on"
+                style="@style/MyTextSwitch"
+                app:showText="true"
+                app:switchTextAppearance="@style/MyInfoText"
+                app:thumbTextPadding="4dp"
+                app:thumbTint="#444488"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/showchords" />
+
+            <LinearLayout
+                android:id="@+id/group_alignment"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/lyrics_title_align"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
                     <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/maxfontsize" />
-
-                    <SeekBar
-                        android:id="@+id/setMaxFontSizeProgressBar"
-                        style="?android:attr/progressBarStyleHorizontal"
+                        style="@style/MyHeadingText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        android:id="@+id/maxfontSizePreview"
-                        style="@style/MyInfoText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="24dp" />
-
-                </LinearLayout>
-
-
-                <LinearLayout
-                    android:id="@+id/group_manualfontsize"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/choose_fontsize" />
-
-                    <SeekBar
-                        android:id="@+id/setFontSizeProgressBar"
-                        style="?android:attr/progressBarStyleHorizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        android:id="@+id/fontSizePreview"
-                        style="@style/MyInfoText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="24dp" />
-
-                </LinearLayout>
-
-                <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/blockShadow"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/block_text_shadow"
-                    style="@style/MyWhiteHeadingText"
-                    android:layout_marginStart="12dp"
-                    android:layout_marginEnd="12dp"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginBottom="24dp"
-                    android:theme="@style/SwitchStyle" />
-
-                <LinearLayout
-                    android:id="@+id/blockShadowAlphaLayout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/block_shadow_opacity" />
-
-                    <SeekBar
-                        android:id="@+id/blockShadowAlpha"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="24dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/group_alignment"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:id="@+id/lyrics_title_align"
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_margin="12dp"
+                        android:layout_margin="8dp"
                         android:text="@string/edit_song_lyrics" />
-
-                    <HorizontalScrollView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="start|center_horizontal">
-
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:orientation="horizontal">
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_left_align"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_align_left_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="Left"
-                                tools:ignore="HardcodedText" />
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_center_align"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_align_center_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="Center"
-                                tools:ignore="HardcodedText" />
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_right_align"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_align_right_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="Right"
-                                tools:ignore="HardcodedText" />
-
-                            <View
-                                android:id="@+id/divider"
-                                android:layout_width="18dp"
-                                android:layout_height="match_parent"
-                                android:background="?android:attr/listDivider" />
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_top_valign"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_vertical_align_top_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="@string/top" />
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_center_valign"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_vertical_align_center_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="Middle"
-                                tools:ignore="HardcodedText" />
-
-                            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/lyrics_bottom_valign"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:src="@drawable/ic_format_vertical_align_bottom_white_36dp"
-                                app:backgroundTint="#555555"
-                                app:elevation="0dp"
-                                app:fabSize="mini"
-                                app:useCompatPadding="true"
-                                android:contentDescription="@string/bottom" />
-
-                        </LinearLayout>
-
-                    </HorizontalScrollView>
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_margin="12dp"
-                        android:text="@string/presoInfoFont" />
 
                     <HorizontalScrollView
                         android:layout_width="wrap_content"
@@ -496,53 +203,99 @@
                             android:orientation="horizontal">
 
                             <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/info_left_align"
+                                android:id="@+id/lyrics_left_align"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
+                                android:layout_marginEnd="12dp"
+                                android:contentDescription="Left"
                                 android:src="@drawable/ic_format_align_left_white_36dp"
                                 app:backgroundTint="#555555"
                                 app:elevation="0dp"
                                 app:fabSize="mini"
                                 app:useCompatPadding="true"
-                                android:contentDescription="Left"
                                 tools:ignore="HardcodedText" />
 
                             <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/info_center_align"
+                                android:id="@+id/lyrics_center_align"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
+                                android:layout_marginStart="12dp"
+                                android:layout_marginEnd="12dp"
+                                android:contentDescription="Center"
                                 android:src="@drawable/ic_format_align_center_white_36dp"
                                 app:backgroundTint="#555555"
                                 app:elevation="0dp"
                                 app:fabSize="mini"
                                 app:useCompatPadding="true"
-                                android:contentDescription="Center"
                                 tools:ignore="HardcodedText" />
 
                             <com.google.android.material.floatingactionbutton.FloatingActionButton
-                                android:id="@+id/info_right_align"
+                                android:id="@+id/lyrics_right_align"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="0dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
+                                android:layout_marginStart="12dp"
+                                android:contentDescription="Right"
                                 android:src="@drawable/ic_format_align_right_white_36dp"
                                 app:backgroundTint="#555555"
                                 app:elevation="0dp"
                                 app:fabSize="mini"
                                 app:useCompatPadding="true"
-                                android:contentDescription="Right"
                                 tools:ignore="HardcodedText" />
 
+                        </LinearLayout>
+
+                    </HorizontalScrollView>
+
+                    <HorizontalScrollView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center">
+
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginTop="12dp"
+                            android:layout_marginBottom="12dp"
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                                android:id="@+id/lyrics_top_valign"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                 android:layout_marginEnd="12dp"
+                                android:contentDescription="@string/top"
+                                android:src="@drawable/ic_format_vertical_align_top_white_36dp"
+                                app:backgroundTint="#555555"
+                                app:elevation="0dp"
+                                app:fabSize="mini"
+                                app:useCompatPadding="true" />
+
+                            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                                android:id="@+id/lyrics_center_valign"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="12dp"
+                                android:layout_marginEnd="12dp"
+                                android:contentDescription="Middle"
+                                android:src="@drawable/ic_format_vertical_align_center_white_36dp"
+                                app:backgroundTint="#555555"
+                                app:elevation="0dp"
+                                app:fabSize="mini"
+                                app:useCompatPadding="true"
+                                tools:ignore="HardcodedText" />
+
+                            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                                android:id="@+id/lyrics_bottom_valign"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="12dp"
+                                android:contentDescription="@string/bottom"
+                                android:src="@drawable/ic_format_vertical_align_bottom_white_36dp"
+                                app:backgroundTint="#555555"
+                                app:elevation="0dp"
+                                app:fabSize="mini"
+                                app:useCompatPadding="true" />
 
                         </LinearLayout>
 
@@ -550,323 +303,458 @@
 
                 </LinearLayout>
 
-                <LinearLayout
-                    android:id="@+id/group_songinfofontsizes"
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/boldTextButton"
+                    android:textColor="#ff0"
+                    android:textOff="@string/off"
+                    android:textOn="@string/on"
+                    style="@style/MyTextSwitch"
+                    app:showText="true"
+                    app:switchTextAppearance="@style/MyInfoText"
+                    app:thumbTextPadding="4dp"
+                    app:thumbTint="#444488"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_margin="8dp"
+                    android:text="@string/bold_text" />
 
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/edit_song_title" />
-
-                    <SeekBar
-                        android:id="@+id/presoTitleSizeSeekBar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:focusableInTouchMode="false"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/edit_song_author" />
-
-                    <SeekBar
-                        android:id="@+id/presoAuthorSizeSeekBar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/edit_song_copyright" />
-
-                    <SeekBar
-                        android:id="@+id/presoCopyrightSizeSeekBar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo" />
-
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/alert" />
-
-                    <SeekBar
-                        android:id="@+id/presoAlertSizeSeekBar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
-
-
-                </LinearLayout>
-
-
-                <LinearLayout
-                    android:id="@+id/group_backgrounds"
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/blockShadow"
+                    android:textColor="#ff0"
+                    android:textOff="@string/off"
+                    android:textOn="@string/on"
+                    style="@style/MyTextSwitch"
+                    app:showText="true"
+                    app:switchTextAppearance="@style/MyInfoText"
+                    app:thumbTextPadding="4dp"
+                    app:thumbTint="#444488"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/block_text_shadow" />
 
-                    <TextView
-                        style="@style/MyWhiteHeadingText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="0dp"
-                        android:text="@string/preso_alpha" />
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/block_shadow_opacity" />
 
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-                    <SeekBar
-                        android:id="@+id/presoAlphaProgressBar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="12dp"
-                        android:background="@drawable/apptheme_scrubber_primary_holo"
-                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+                <SeekBar
+                    android:id="@+id/blockShadowAlpha"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:max="100"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
 
-                    <TextView
-                        android:id="@+id/presoAlphaText"
-                        style="@style/MyInfoText"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginLeft="12dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginRight="12dp"
-                        android:layout_marginBottom="24dp" />
-
-                    <TableLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="horizontal">
-
-                        <TableRow>
-
-                            <TextView
-                                style="@style/MyWhiteHeadingText"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_column="0"
-                                android:layout_gravity="center_vertical"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="12dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:layout_weight="1"
-                                android:text="@string/logo" />
-
-                            <ImageView
-                                android:id="@+id/chooseLogoButton"
-                                android:layout_width="120dp"
-                                android:layout_height="90dp"
-                                android:layout_column="1"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="12dp"
-                                android:contentDescription="@string/logo"
-                                android:src="@drawable/ic_image_white_36dp" />
-
-                        </TableRow>
-
-                        <TableRow>
-
-                            <TextView
-                                style="@style/MyWhiteHeadingText"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_column="0"
-                                android:layout_gravity="center_vertical"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="12dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:layout_weight="1"
-                                android:text="@string/choose_image1" />
-
-                            <ImageView
-                                android:id="@+id/chooseImage1Button"
-                                android:layout_width="120dp"
-                                android:layout_height="90dp"
-                                android:layout_column="1"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="12dp"
-                                android:contentDescription="@string/choose_image1"
-                                android:src="@drawable/ic_image_white_36dp" />
-
-                            <CheckBox
-                                android:id="@+id/image1CheckBox"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_column="3"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="24dp" />
-                        </TableRow>
-
-                        <TableRow>
-
-                            <TextView
-                                style="@style/MyWhiteHeadingText"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_column="0"
-                                android:layout_gravity="center_vertical"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="12dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:layout_weight="1"
-                                android:text="@string/choose_image2" />
-
-                            <ImageView
-                                android:id="@+id/chooseImage2Button"
-                                android:layout_width="120dp"
-                                android:layout_height="90dp"
-                                android:layout_column="1"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="12dp"
-                                android:contentDescription="@string/choose_image2"
-                                android:src="@drawable/ic_image_white_36dp" />
-
-                            <CheckBox
-                                android:id="@+id/image2CheckBox"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_column="3"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="24dp" />
-                        </TableRow>
-
-                        <TableRow>
-
-                            <TextView
-                                style="@style/MyWhiteHeadingText"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_column="0"
-                                android:layout_gravity="center_vertical"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="12dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:layout_weight="1"
-                                android:text="@string/choose_video1" />
-
-                            <ImageView
-                                android:id="@+id/chooseVideo1Button"
-                                android:layout_width="120dp"
-                                android:layout_height="90dp"
-                                android:layout_column="1"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="12dp"
-                                android:contentDescription="@string/choose_video1"
-                                android:src="@drawable/ic_image_white_36dp"
-                                tools:ignore="TooManyViews" />
-
-                            <CheckBox
-                                android:id="@+id/video1CheckBox"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_column="3"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="24dp"
-                                tools:ignore="TooManyViews" />
-                        </TableRow>
-
-                        <TableRow>
-
-                            <TextView
-                                style="@style/MyWhiteHeadingText"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_column="0"
-                                android:layout_gravity="center_vertical"
-                                android:layout_marginLeft="12dp"
-                                android:layout_marginTop="12dp"
-                                android:layout_marginRight="12dp"
-                                android:layout_marginBottom="0dp"
-                                android:layout_weight="1"
-                                android:text="@string/choose_video2" />
-
-                            <ImageView
-                                android:id="@+id/chooseVideo2Button"
-                                android:layout_width="120dp"
-                                android:layout_height="90dp"
-                                android:layout_column="1"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="12dp"
-                                android:contentDescription="@string/choose_video2"
-                                android:src="@drawable/ic_image_white_36dp"
-                                tools:ignore="TooManyViews" />
-
-                            <CheckBox
-                                android:id="@+id/video2CheckBox"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_column="3"
-                                android:layout_gravity="center_vertical"
-                                android:layout_margin="24dp" />
-                        </TableRow>
-
-                    </TableLayout>
+                <TextView
+                    android:id="@+id/blockShadowAlphaText"
+                    style="@style/MyInfoText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp" />
 
                 </LinearLayout>
 
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/group_songinfofontsizes"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/presoInfoFont" />
+
+                <HorizontalScrollView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/info_left_align"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="12dp"
+                            android:contentDescription="Left"
+                            android:src="@drawable/ic_format_align_left_white_36dp"
+                            app:backgroundTint="#555555"
+                            app:elevation="0dp"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true"
+                            tools:ignore="HardcodedText" />
+
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/info_center_align"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:layout_marginEnd="12dp"
+                            android:contentDescription="Center"
+                            android:src="@drawable/ic_format_align_center_white_36dp"
+                            app:backgroundTint="#555555"
+                            app:elevation="0dp"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true"
+                            tools:ignore="HardcodedText" />
+
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/info_right_align"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:contentDescription="Right"
+                            android:src="@drawable/ic_format_align_right_white_36dp"
+                            app:backgroundTint="#555555"
+                            app:elevation="0dp"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true"
+                            tools:ignore="HardcodedText" />
+
+                    </LinearLayout>
+
+                </HorizontalScrollView>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/edit_song_title" />
+
+                <SeekBar
+                    android:id="@+id/presoTitleSizeSeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:focusableInTouchMode="false"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/edit_song_author" />
+
+                <SeekBar
+                    android:id="@+id/presoAuthorSizeSeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/edit_song_copyright" />
+
+                <SeekBar
+                    android:id="@+id/presoCopyrightSizeSeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo" />
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/alert" />
+
+                <SeekBar
+                    android:id="@+id/presoAlertSizeSeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/group_backgrounds"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/preso_alpha" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                <SeekBar
+                    android:id="@+id/presoAlphaProgressBar"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:max="100"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
+
+                <TextView
+                    android:id="@+id/presoAlphaText"
+                    style="@style/MyInfoText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp" />
+
+                </LinearLayout>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/choose_image1" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" >
+
+                    <ImageView
+                        android:id="@+id/chooseImage1Button"
+                        android:layout_width="120dp"
+                        android:layout_height="90dp"
+                        android:layout_margin="12dp"
+                        android:contentDescription="@string/choose_image1"
+                        android:src="@drawable/ic_image_white_36dp" />
+
+                    <CheckBox
+                        android:id="@+id/image1CheckBox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_margin="12dp"
+                        android:shadowColor="#FFFFFF" />
+                </LinearLayout>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/choose_image2" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" >
+
+                    <ImageView
+                        android:id="@+id/chooseImage2Button"
+                        android:layout_width="120dp"
+                        android:layout_height="90dp"
+                        android:layout_margin="12dp"
+                        android:contentDescription="@string/choose_image2"
+                        android:src="@drawable/ic_image_white_36dp" />
+
+                    <CheckBox
+                        android:id="@+id/image2CheckBox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_margin="12dp" />
+
+                </LinearLayout>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/choose_video1" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" >
+
+                        <ImageView
+                            android:id="@+id/chooseVideo1Button"
+                            android:layout_width="120dp"
+                            android:layout_height="90dp"
+                            android:layout_margin="12dp"
+                            android:contentDescription="@string/choose_video1"
+                            android:src="@drawable/ic_image_white_36dp"
+                            tools:ignore="TooManyViews" />
+
+                        <CheckBox
+                            android:id="@+id/video1CheckBox"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:layout_margin="12dp"
+                            tools:ignore="TooManyViews" />
+
+                </LinearLayout>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/choose_video2" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" >
+
+                    <ImageView
+                        android:id="@+id/chooseVideo2Button"
+                        android:layout_width="120dp"
+                        android:layout_height="90dp"
+                        android:layout_margin="12dp"
+                        android:contentDescription="@string/choose_video2"
+                        android:src="@drawable/ic_image_white_36dp"
+                        tools:ignore="TooManyViews" />
+
+                    <CheckBox
+                        android:id="@+id/video2CheckBox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_margin="12dp" />
+
+                </LinearLayout>
+
+                <TextView
+                    style="@style/MyHeadingText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/logo" />
+
+                <LinearLayout
+                    android:layout_width="200dp"
+                    android:layout_height="wrap_content" >
+
+                    <ImageView
+                        android:id="@+id/chooseLogoButton"
+                        android:layout_width="120dp"
+                        android:layout_height="90dp"
+                        android:layout_margin="8dp"
+                        android:contentDescription="@string/logo"
+                        android:src="@drawable/ic_image_white_36dp"
+                        tools:ignore="TooManyViews" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <TextView
+                style="@style/MyHeadingText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/setxmargins" />
+
+            <SeekBar
+                android:id="@+id/setXMarginProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:background="@drawable/apptheme_scrubber_primary_holo"
+                android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+
+            <TextView
+                style="@style/MyHeadingText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/setymargins" />
+
+            <SeekBar
+                android:id="@+id/setYMarginProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:background="@drawable/apptheme_scrubber_primary_holo"
+                android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
+
+            <TextView
+                style="@style/MyHeadingText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/rotate_display" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal">
+
+                <SeekBar
+                    android:id="@+id/setRotationProgressBar"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/apptheme_scrubber_primary_holo"
+                    android:max="100"
+                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
+
+                <TextView
+                    android:id="@+id/rotationTextView"
+                    style="@style/MyInfoText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/zerotime" />
+
+            </LinearLayout>
+
         </LinearLayout>
+
     </ScrollView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/popup_option_connections.xml
+++ b/app/src/main/res/layout/popup_option_connections.xml
@@ -191,7 +191,8 @@
                     android:id="@+id/searchForHosts"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="8dp"
+                    android:layout_margin="4dp"
+                    android:padding="4dp"
                     android:text="@string/connections_discover" />
 
         </LinearLayout>
@@ -229,8 +230,8 @@
             style="@style/MyInfoText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="2dp"
-            android:padding="4dp"
+            android:layout_margin="4dp"
+            android:padding="2dp"
             android:text="@string/connections_log" />
 
         </LinearLayout>


### PR DESCRIPTION
Hello Gareth,

Glad to hear your Mac is flying!

I needed a 'Lyrics Only' format for 'Stage Mode' and took the opportunity to fix HDMI and mode change quirks.  These give 'Stage Mode' a new 'Lyrics Only' format (and as a bonus greater alignment flexibility for 'Chords and Lyrics' format in presentation mode).

A user in stage mode with HDMI output does not have to connect to another device to get 'Lyrics Only' displayed using that device.  They might be happy to use Stage Mode in this new Lyrics Only format and cable up their own device!

I have tweaked nearby to allow users to change their mind about settings or simply re-display the last host song.

I would love some feedback on these changes.  I am happy to adjust.

Kind regards
Ian V





