### PR TITLE
Connected Display Tweak (2)

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
@@ -211,7 +211,6 @@ class ExportPreparer {
         Uri onsong = null;
         Uri image = null;
         Uri pdf = null;
-        // IV - Moved pdfbmp into relevant PDF section
 
         // Prepare the song uri and input stream
         Uri uriinput = storageAccess.getUriForItem(c, preferences, "Songs", StaticVariables.whichSongFolder,

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
@@ -257,7 +257,8 @@ public class PopUpLayoutFragment extends DialogFragment {
             setCheckBoxes();
         }
         setXMarginProgressBar.setMax(150);
-        setYMarginProgressBar.setMax(150);
+        // IV - Allow bigger margin to give smaller active height suitable for use as bottom 3rd overlay of words over video
+        setYMarginProgressBar.setMax(250);
         setXMarginProgressBar.setProgress(preferences.getMyPreferenceInt(getContext(),"presoXMargin",20));
         setYMarginProgressBar.setProgress(preferences.getMyPreferenceInt(getContext(),"presoYMargin",10));
         setRotationProgressBar.setMax(3);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
@@ -215,7 +215,7 @@ public class PopUpLayoutFragment extends DialogFragment {
             showorhideView(group_manualfontsize, !toggleAutoScaleButton.isChecked());
             boldTextButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoLyricsBold",false));
         } else {
-            // IV - Stage and Perfomance modes do not support manual font size, bold or show alerts
+            // IV - Stage and Performance modes do not support manual font size, bold or show alerts
             toggleAutoScaleButton.setVisibility(View.GONE);
             showorhideView(group_maxfontsize, true);
             showorhideView(group_manualfontsize, false);
@@ -349,6 +349,7 @@ public class PopUpLayoutFragment extends DialogFragment {
                     e.printStackTrace();
                 }
             }
+            setUpAlignmentButtons();
         });
         boldTextButton.setOnCheckedChangeListener((compoundButton, b) -> {
             preferences.setMyPreferenceBoolean(getContext(),"presoLyricsBold",b);
@@ -549,7 +550,8 @@ public class PopUpLayoutFragment extends DialogFragment {
     private void setUpAlignmentButtons() {
 
 
-        if (StaticVariables.whichMode.equals("Stage") || StaticVariables.whichMode.equals("Presentation")) {
+        if ((StaticVariables.whichMode.equals("Stage") && !preferences.getMyPreferenceBoolean(getContext(), "presoShowChords", false)) ||
+                StaticVariables.whichMode.equals("Presentation")) {
 
             int lyralign = preferences.getMyPreferenceInt(getContext(), "presoLyricsAlign", Gravity.CENTER_HORIZONTAL);
             int lyrvalign = preferences.getMyPreferenceInt(getContext(), "presoLyricsVAlign", Gravity.CENTER_VERTICAL);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLayoutFragment.java
@@ -67,7 +67,7 @@ public class PopUpLayoutFragment extends DialogFragment {
     private TextView fontSizePreview;
     private TextView presoAlphaText;
     private LinearLayout lyrics_title_align;
-    private LinearLayout group_songinfofontsizes;
+    private TextView presoAlertText;
     private TextView presoTransitionTimeTextView;
     private TextView rotationTextView;
     private FloatingActionButton lyrics_left_align, lyrics_center_align, lyrics_right_align,
@@ -150,7 +150,7 @@ public class PopUpLayoutFragment extends DialogFragment {
         setMaxFontSizeProgressBar = V.findViewById(R.id.setMaxFontSizeProgressBar);
         maxfontSizePreview = V.findViewById(R.id.maxfontSizePreview);
         group_manualfontsize = V.findViewById(R.id.group_manualfontsize);
-        group_songinfofontsizes = V.findViewById(R.id.group_songinfofontsizes);
+        presoAlertText = V.findViewById(R.id.presoAlertText);
         setFontSizeProgressBar = V.findViewById(R.id.setFontSizeProgressBar);
         fontSizePreview = V.findViewById(R.id.fontSizePreview);
         lyrics_title_align = V.findViewById(R.id.lyrics_title_align);
@@ -215,11 +215,13 @@ public class PopUpLayoutFragment extends DialogFragment {
             showorhideView(group_manualfontsize, !toggleAutoScaleButton.isChecked());
             boldTextButton.setChecked(preferences.getMyPreferenceBoolean(getContext(),"presoLyricsBold",false));
         } else {
+            // IV - Stage and Perfomance modes do not support manual font size, bold or show alerts
             toggleAutoScaleButton.setVisibility(View.GONE);
             showorhideView(group_maxfontsize, true);
             showorhideView(group_manualfontsize, false);
             boldTextButton.setVisibility(View.GONE);
-            group_songinfofontsizes.setVisibility(View.GONE);
+            presoAlertText.setVisibility(View.GONE);
+            presoAlertSizeSeekBar.setVisibility(View.GONE);
         }
         setMaxFontSizeProgressBar.setMax(70);
         int progress = (int)preferences.getMyPreferenceFloat(getContext(),"fontSizePresoMax",40.0f) - 4;
@@ -252,10 +254,8 @@ public class PopUpLayoutFragment extends DialogFragment {
         presoTransitionTimeSeekBar.setProgress(timeToSeekBarProgress());
         presoTransitionTimeTextView.setText(SeekBarProgressToText());
         setupPreviews();
-        // IV - Only Presentation mode starts with a background
-        if (StaticVariables.whichMode.equals("Presentation")) {
-            setCheckBoxes();
-        }
+        setCheckBoxes();
+
         setXMarginProgressBar.setMax(150);
         // IV - Allow bigger margin to give smaller active height suitable for use as bottom 3rd overlay of words over video
         setYMarginProgressBar.setMax(250);
@@ -349,8 +349,6 @@ public class PopUpLayoutFragment extends DialogFragment {
                     e.printStackTrace();
                 }
             }
-            sendUpdateToScreen("chords");
-            setUpAlignmentButtons();
         });
         boldTextButton.setOnCheckedChangeListener((compoundButton, b) -> {
             preferences.setMyPreferenceBoolean(getContext(),"presoLyricsBold",b);
@@ -550,13 +548,11 @@ public class PopUpLayoutFragment extends DialogFragment {
 
     private void setUpAlignmentButtons() {
 
-        // IV  - Only used for specific situations
-        if ((StaticVariables.whichMode.equals("Stage") && !(preferences.getMyPreferenceBoolean(getContext(),"presoShowChords",false))) ||
-                StaticVariables.whichMode.equals("Presentation")) {
+
+        if (StaticVariables.whichMode.equals("Stage") || StaticVariables.whichMode.equals("Presentation")) {
 
             int lyralign = preferences.getMyPreferenceInt(getContext(), "presoLyricsAlign", Gravity.CENTER_HORIZONTAL);
             int lyrvalign = preferences.getMyPreferenceInt(getContext(), "presoLyricsVAlign", Gravity.CENTER_VERTICAL);
-            int infalign = preferences.getMyPreferenceInt(getContext(), "presoInfoAlign", Gravity.END);
 
             if (lyralign == Gravity.START) {
                 lyrics_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
@@ -584,22 +580,26 @@ public class PopUpLayoutFragment extends DialogFragment {
                 lyrics_center_valign.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
                 lyrics_bottom_valign.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
             }
-            if (infalign == Gravity.START) {
-                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
-                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            } else if (infalign == Gravity.END) {
-                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
-            } else { // CENTER_HORIZONTAL
-                info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-                info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
-                info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
-            }
             lyrics_title_align.setVisibility(View.VISIBLE);
         } else {
             lyrics_title_align.setVisibility(View.GONE);
+        }
+
+        // IV - Info is always shown
+        int infalign = preferences.getMyPreferenceInt(getContext(), "presoInfoAlign", Gravity.END);
+
+        if (infalign == Gravity.START) {
+            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+        } else if (infalign == Gravity.END) {
+            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+        } else { // CENTER_HORIZONTAL
+            info_left_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
+            info_center_align.setBackgroundTintList(ColorStateList.valueOf(0xff444488));
+            info_right_align.setBackgroundTintList(ColorStateList.valueOf(0xff555555));
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLyricsSettings.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLyricsSettings.java
@@ -176,15 +176,6 @@ public class PopUpLyricsSettings extends DialogFragment {
             preferences.setMyPreferenceBoolean(getContext(),"trimLines",b);
         });
         songPresentationOrderSwitch.setOnCheckedChangeListener(new SaveCheckedState("usePresentationOrder"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-        songLyricsBoxSwitch.setOnCheckedChangeListener(new SaveCheckedState("hideLyricsBox"));
-
         scaleHeading_SeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresentationCommon.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresentationCommon.java
@@ -30,7 +30,7 @@ class PresentationCommon {
     // IV - Lyric display is delayed for a change of infobar - not at other times
     long infoBarChangeDelay;
     long infoBarUntilTime;
-    String infoBarAlertState;
+    String infoBarAlertState = PresenterMode.alert_on;
     // IV - Support for 'last change only' fade in of content
     long lyricAfterTime;
     long lyricDelay;
@@ -91,7 +91,7 @@ class PresentationCommon {
     void setDefaultBackgroundImage(Context c) {
         StaticVariables.cast_defimage = ResourcesCompat.getDrawable(c.getResources(),R.drawable.preso_default_bg, null);
     }
-    boolean matchPresentationToMode(TextView songinfo_TextView, LinearLayout presentermode_bottombit,
+    boolean matchPresentationToMode(LinearLayout presentermode_bottombit,
                                     SurfaceView projected_SurfaceView, ImageView projected_BackgroundImage,
                                     ImageView projected_ImageView) {
         boolean runfixbackground = false;
@@ -99,9 +99,7 @@ class PresentationCommon {
             case "Stage":
             case "Performance":
             default:
-                songinfo_TextView.setAlpha(0.0f);
-                songinfo_TextView.setVisibility(View.VISIBLE);
-                presentermode_bottombit.setVisibility(View.GONE);
+                presentermode_bottombit.setVisibility(View.VISIBLE);
                 projected_SurfaceView.setVisibility(View.GONE);
                 projected_BackgroundImage.setImageDrawable(null);
                 projected_BackgroundImage.setVisibility(View.GONE);
@@ -109,7 +107,6 @@ class PresentationCommon {
                 break;
 
             case "Presentation":
-                songinfo_TextView.setVisibility(View.GONE);
                 presentermode_bottombit.setVisibility(View.VISIBLE);
                 runfixbackground = true;
                 break;
@@ -117,8 +114,7 @@ class PresentationCommon {
         StaticVariables.forcecastupdate = false;
         return runfixbackground;
     }
-    void changeMargins(Context c, Preferences preferences, TextView songinfo_TextView, RelativeLayout projectedPage_RelativeLayout, int presoInfoColor) {
-        songinfo_TextView.setTextColor(presoInfoColor);
+    void changeMargins(Context c, Preferences preferences, RelativeLayout projectedPage_RelativeLayout, int presoInfoColor) {
         projectedPage_RelativeLayout.setPadding(preferences.getMyPreferenceInt(c,"presoXMargin",20)+StaticVariables.cast_padding,
                 preferences.getMyPreferenceInt(c,"presoYMargin",10)+StaticVariables.cast_padding,
                 preferences.getMyPreferenceInt(c,"presoXMargin",20)+StaticVariables.cast_padding,
@@ -337,7 +333,7 @@ class PresentationCommon {
         presentermode_ccli.setGravity(preferences.getMyPreferenceInt(c,"presoInfoAlign", Gravity.END));
         // IV - Align alert text the same as lyrics
         presentermode_alert.setGravity(preferences.getMyPreferenceInt(c,"presoLyricsAlign", Gravity.END));
-        presentermode_bottombit.setBackgroundColor(ColorUtils.setAlphaComponent(StaticVariables.cast_presoShadowColor,100));
+        presentermode_bottombit.setBackgroundColor(ColorUtils.setAlphaComponent(StaticVariables.cast_presoShadowColor, 100));
     }
     void presenterStartUp(final Context c, final Preferences preferences, final StorageAccess storageAccess, final ImageView projected_BackgroundImage,
                           final SurfaceHolder projected_SurfaceHolder, final SurfaceView projected_SurfaceView) {
@@ -498,7 +494,7 @@ class PresentationCommon {
     }
     // Update the screen content
     void doUpdate(final Context c, final Preferences preferences, final StorageAccess storageAccess, final ProcessSong processSong,
-                  final Display myscreen, final TextView songinfo_TextView, LinearLayout presentermode_bottombit, final SurfaceView projected_SurfaceView,
+                  final Display myscreen, LinearLayout presentermode_bottombit, final SurfaceView projected_SurfaceView,
                   ImageView projected_BackgroundImage, RelativeLayout pageHolder, ImageView projected_Logo, final ImageView projected_ImageView,
                   final LinearLayout projected_LinearLayout, LinearLayout bottom_infobar, final RelativeLayout projectedPage_RelativeLayout,
                   TextView presentermode_title, TextView presentermode_author, TextView presentermode_copyright, TextView presentermode_ccli, TextView presentermode_alert,
@@ -516,7 +512,7 @@ class PresentationCommon {
 
             // If we have forced an update due to switching modes, set that up
             if (StaticVariables.forcecastupdate) {
-                matchPresentationToMode(songinfo_TextView, presentermode_bottombit, projected_SurfaceView, projected_BackgroundImage, projected_ImageView);
+                matchPresentationToMode(presentermode_bottombit, projected_SurfaceView, projected_BackgroundImage, projected_ImageView);
             }
 
             // If we had a black screen, fade page back in
@@ -535,31 +531,24 @@ class PresentationCommon {
                 // If on running the time test fails a newer postDelayed has been made
                 // After the panic delay time, make sure the correct view is visible regardless of animations
                 if (StaticVariables.panicRequired && !animateOutActive && ((panicAfterTime - 5) < System.currentTimeMillis())) {
-                    if (StaticVariables.whichMode.equals("Presentation")) {
-                        if (FullscreenActivity.isImage || FullscreenActivity.isPDF || FullscreenActivity.isImageSlide) {
-                            projected_ImageView.setVisibility(View.VISIBLE);
-                            projected_LinearLayout.setVisibility(View.GONE);
-                            projected_ImageView.setAlpha(1.0f);
-                        } else if (FullscreenActivity.isVideo) {
-                            projected_SurfaceView.setVisibility(View.VISIBLE);
-                            projected_LinearLayout.setVisibility(View.GONE);
-                            projected_ImageView.setVisibility(View.GONE);
-                            //projected_SurfaceView.setAlpha(1.0f);
-                        } else {
-                            projected_LinearLayout.setVisibility(View.VISIBLE);
-                            projected_ImageView.setVisibility(View.GONE);
-                            projected_LinearLayout.setAlpha(1.0f);
-                        }
+                    if (FullscreenActivity.isImage || FullscreenActivity.isPDF || FullscreenActivity.isImageSlide) {
+                        projected_ImageView.setVisibility(View.VISIBLE);
+                        projected_LinearLayout.setVisibility(View.GONE);
+                        projected_ImageView.setAlpha(1.0f);
+                    } else if (FullscreenActivity.isVideo) {
+                        projected_SurfaceView.setVisibility(View.VISIBLE);
+                        projected_LinearLayout.setVisibility(View.GONE);
+                        projected_ImageView.setVisibility(View.GONE);
+                        //projected_SurfaceView.setAlpha(1.0f);
+                    } else {
+                        projected_LinearLayout.setVisibility(View.VISIBLE);
+                        projected_ImageView.setVisibility(View.GONE);
+                        projected_LinearLayout.setAlpha(1.0f);
                     }
                 }
             }, panicDelay);
 
-            if (StaticVariables.whichMode.equals("Presentation")) {
-                // IV - Show the infobar as needed
-                presenterWriteSongInfo(c, preferences, presentermode_title, presentermode_author, presentermode_copyright, presentermode_ccli, presentermode_alert, bottom_infobar);
-            } else {
-                standardWriteSongInfo(c, preferences, songinfo_TextView, bottom_infobar);
-            }
+            presenterWriteSongInfo(c, preferences, presentermode_title, presentermode_author, presentermode_copyright, presentermode_ccli, presentermode_alert, bottom_infobar);
 
             // IV - There can be multiple postDelayed calls running, each call sets a later 'After' time.
             lyricDelay = preferences.getMyPreferenceInt(c, "presoTransitionTime", 800) + infoBarChangeDelay;
@@ -580,7 +569,6 @@ class PresentationCommon {
                     if (!StaticVariables.whichMode.equals("Presentation")) {
                         // Set the page background to the correct colour for Peformance/Stage modes
                         projectedPage_RelativeLayout.setBackgroundColor(StaticVariables.cast_lyricsBackgroundColor);
-                        songinfo_TextView.setTextColor(StaticVariables.cast_presoInfoColor);
                     }
 
                     // Get the size of the SurfaceView here as any infobar will be visible at this point
@@ -711,30 +699,6 @@ class PresentationCommon {
             v.setVisibility(View.GONE);
         } else {
             v.setVisibility(View.VISIBLE);
-        }
-    }
-    private void standardWriteSongInfo(Context c, Preferences preferences, TextView songinfo_TextView, LinearLayout bottom_infobar) {
-        String old_title = songinfo_TextView.getText().toString();
-        String new_title = StaticVariables.mTitle;
-        if (!StaticVariables.mAuthor.equals("")) {
-            new_title = new_title + "\n" + StaticVariables.mAuthor;
-        }
-        // IV - If we have something or are not yet displaying, cross fade in
-        if (!old_title.equals(new_title) ||  songinfo_TextView.getAlpha() == 0.0f) {
-            CustomAnimations.faderAnimation(bottom_infobar,preferences.getMyPreferenceInt(c,"presoTransitionTime",800),false);
-            // IV - Now run the next bit post delayed (to wait for the animate out)
-            if (!(FullscreenActivity.isImage || FullscreenActivity.isImageSlide || FullscreenActivity.isPDF) && (!new_title.isEmpty())) {
-                Handler h = new Handler();
-                String finalNew_title = new_title;
-                h.postDelayed(() -> {
-                    songinfo_TextView.setTextColor(StaticVariables.cast_presoInfoColor);
-                    songinfo_TextView.setText(finalNew_title);
-                    songinfo_TextView.setAlpha(1.0f);
-                    CustomAnimations.faderAnimation(bottom_infobar,preferences.getMyPreferenceInt(c,"presoTransitionTime",800),true);
-                }, preferences.getMyPreferenceInt(c, "presoTransitionTime", 800));
-            } else {
-                songinfo_TextView.setText(new_title);
-            }
         }
     }
     private void doPDFPage(Context c, Preferences preferences, StorageAccess storageAccess, ProcessSong processSong, ImageView projected_ImageView, LinearLayout projected_LinearLayout) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresentationService.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresentationService.java
@@ -101,7 +101,7 @@ public class PresentationService extends CastRemoteDisplayLocalService {
         @SuppressLint("StaticFieldLeak")
         private static ImageView projected_ImageView, projected_Logo, projected_BackgroundImage;
         @SuppressLint("StaticFieldLeak")
-        private static TextView songinfo_TextView, presentermode_title, presentermode_author,
+        private static TextView presentermode_title, presentermode_author,
                 presentermode_copyright, presentermode_ccli, presentermode_alert;
         @SuppressLint("StaticFieldLeak")
         private static LinearLayout bottom_infobar, col1_1, col1_2, col2_2, col1_3, col2_3, col3_3;
@@ -156,11 +156,9 @@ public class PresentationService extends CastRemoteDisplayLocalService {
                 // Prepare the display after 2 secs (a chance for stuff to be measured and show the logo
                 Handler h = new Handler();
                 h.postDelayed(() -> {
+                    presenterStartUp();
                     if (!StaticVariables.whichMode.equals("Presentation")) {
                         normalStartUp();
-                    } else {
-                        // Switch to the user background and logo
-                        presenterStartUp();
                     }
                 }, 2000);
 
@@ -180,7 +178,6 @@ public class PresentationService extends CastRemoteDisplayLocalService {
             projected_SurfaceHolder = projected_SurfaceView.getHolder();
             projected_SurfaceHolder.addCallback(this);
             projected_Logo = findViewById(R.id.projected_Logo);
-            songinfo_TextView = findViewById(R.id.songinfo_TextView);
             presentermode_bottombit = findViewById(R.id.presentermode_bottombit);
             presentermode_title = findViewById(R.id.presentermode_title);
             presentermode_author = findViewById(R.id.presentermode_author);
@@ -217,12 +214,12 @@ public class PresentationService extends CastRemoteDisplayLocalService {
             presentationCommon.setDefaultBackgroundImage(c);
         }
         private static void matchPresentationToMode() {
-            if (presentationCommon.matchPresentationToMode(songinfo_TextView,presentermode_bottombit,projected_SurfaceView,projected_BackgroundImage,projected_ImageView)) {
+            if (presentationCommon.matchPresentationToMode(presentermode_bottombit,projected_SurfaceView,projected_BackgroundImage,projected_ImageView)) {
                 fixBackground();
             }
         }
         static void changeMargins() {
-            presentationCommon.changeMargins(c,preferences,songinfo_TextView,projectedPage_RelativeLayout,StaticVariables.cast_presoInfoColor);
+            presentationCommon.changeMargins(c,preferences,projectedPage_RelativeLayout,StaticVariables.cast_presoInfoColor);
         }
         static void fixBackground() {
             presentationCommon.fixBackground(c,preferences,storageAccess,projected_BackgroundImage,projected_SurfaceHolder,projected_SurfaceView);
@@ -305,7 +302,7 @@ public class PresentationService extends CastRemoteDisplayLocalService {
         // Update the screen content
         static void doUpdate() {
             presentermode_alert.setAlpha(1.0f);
-            presentationCommon.doUpdate(c,preferences,storageAccess,processSong,myscreen,songinfo_TextView,presentermode_bottombit,projected_SurfaceView,
+            presentationCommon.doUpdate(c,preferences,storageAccess,processSong,myscreen,presentermode_bottombit,projected_SurfaceView,
                     projected_BackgroundImage, pageHolder,projected_Logo,projected_ImageView,projected_LinearLayout,bottom_infobar,projectedPage_RelativeLayout,
                     presentermode_title, presentermode_author, presentermode_copyright, presentermode_ccli, presentermode_alert, col1_1, col1_2, col2_2, col1_3, col2_3, col3_3);
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresentationServiceHDMI.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresentationServiceHDMI.java
@@ -44,7 +44,7 @@ import android.widget.TextView;
         @SuppressLint("StaticFieldLeak")
         private static ImageView projected_ImageView, projected_Logo, projected_BackgroundImage;
         @SuppressLint("StaticFieldLeak")
-        private static TextView songinfo_TextView, presentermode_title, presentermode_author,
+        private static TextView presentermode_title, presentermode_author,
                 presentermode_copyright, presentermode_ccli, presentermode_alert;
         @SuppressLint("StaticFieldLeak")
         private static LinearLayout bottom_infobar, col1_1, col1_2, col2_2, col1_3, col2_3, col3_3;
@@ -99,11 +99,9 @@ import android.widget.TextView;
                 // Prepare the display after 2 secs (a chance for stuff to be measured and show the logo
                 Handler h = new Handler();
                 h.postDelayed(() -> {
+                    presenterStartUp();
                     if (!StaticVariables.whichMode.equals("Presentation")) {
                         normalStartUp();
-                    } else {
-                        // Switch to the user background and logo
-                        presenterStartUp();
                     }
                 }, 2000);
 
@@ -123,7 +121,6 @@ import android.widget.TextView;
             projected_SurfaceHolder = projected_SurfaceView.getHolder();
             projected_SurfaceHolder.addCallback(this);
             projected_Logo = findViewById(R.id.projected_Logo);
-            songinfo_TextView = findViewById(R.id.songinfo_TextView);
             presentermode_bottombit = findViewById(R.id.presentermode_bottombit);
             presentermode_title = findViewById(R.id.presentermode_title);
             presentermode_author = findViewById(R.id.presentermode_author);
@@ -160,12 +157,12 @@ import android.widget.TextView;
             presentationCommon.setDefaultBackgroundImage(c);
         }
         private static void matchPresentationToMode() {
-            if (presentationCommon.matchPresentationToMode(songinfo_TextView,presentermode_bottombit,projected_SurfaceView,projected_BackgroundImage,projected_ImageView)) {
+            if (presentationCommon.matchPresentationToMode(presentermode_bottombit,projected_SurfaceView,projected_BackgroundImage,projected_ImageView)) {
                 fixBackground();
             }
         }
         static void changeMargins() {
-            presentationCommon.changeMargins(c,preferences,songinfo_TextView,projectedPage_RelativeLayout,StaticVariables.cast_presoInfoColor);
+            presentationCommon.changeMargins(c,preferences,projectedPage_RelativeLayout,StaticVariables.cast_presoInfoColor);
         }
         static void fixBackground() {
             presentationCommon.fixBackground(c,preferences,storageAccess,projected_BackgroundImage,projected_SurfaceHolder,projected_SurfaceView);
@@ -248,7 +245,7 @@ import android.widget.TextView;
         // Update the screen content
         static void doUpdate() {
             presentermode_alert.setAlpha(1.0f);
-            presentationCommon.doUpdate(c,preferences,storageAccess,processSong,myscreen,songinfo_TextView,presentermode_bottombit,projected_SurfaceView,
+            presentationCommon.doUpdate(c,preferences,storageAccess,processSong,myscreen,presentermode_bottombit,projected_SurfaceView,
                     projected_BackgroundImage, pageHolder,projected_Logo,projected_ImageView,projected_LinearLayout,bottom_infobar,projectedPage_RelativeLayout,
                     presentermode_title, presentermode_author, presentermode_copyright, presentermode_ccli, presentermode_alert, col1_1, col1_2, col2_2, col1_3, col2_3, col3_3);
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -762,40 +762,49 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     }
 
     public void loadSong() {
-        StaticVariables.panicRequired = false;
-        StaticVariables.infoBarChangeRequired = true;
         // IV - Prevent slide shows continuing to be active on change of song(!)
         prepareStopAutoSlideShow();
 
-        if (!FullscreenActivity.alreadyloading) {
-            FullscreenActivity.alreadyloading = true;
-            // Get the song indexes
-            //listSongFiles.getCurrentSongIndex();
+        try {
+            // Only do this once - if we are the process of loading a song already, don't try to do it again!
+            if (!FullscreenActivity.alreadyloading) {
+                // It will get set back to false in the post execute of the async task
+                FullscreenActivity.alreadyloading = true;
 
-            // Don't do this for a blacklisted filetype (application, video, audio)
-            Uri uri = storageAccess.getUriForItem(PresenterMode.this, preferences, "Songs", StaticVariables.whichSongFolder,
-                    StaticVariables.songfilename);
-            if (!storageAccess.checkFileExtensionValid(uri) && !storageAccess.determineFileTypeByExtension()) {
-                StaticVariables.myToastMessage = getResources().getString(R.string.file_type_unknown);
-                ShowToast.showToast(PresenterMode.this);
-            } else {
-                // Declare we have loaded a new song (for the ccli log).
-                // This stops us reporting projecting every section
-                newsongloaded = true;
+                // IV - Set presenting options
+                StaticVariables.panicRequired = false;
+                StaticVariables.infoBarChangeRequired = true;
 
-                // Send Nearby payload
-                if (StaticVariables.isHost && StaticVariables.isConnected) {
-                    nearbyConnections.sendSongPayload();
-                }
+                // Get the song indexes
+                //listSongFiles.getCurrentSongIndex();
 
-                doCancelAsyncTask(loadsong_async);
-                loadsong_async = new LoadSong();
-                try {
-                    loadsong_async.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-                } catch (Exception e) {
-                    // Error loading the song
+                // Don't do this for a blacklisted filetype (application, video, audio)
+                Uri uri = storageAccess.getUriForItem(PresenterMode.this, preferences, "Songs", StaticVariables.whichSongFolder,
+                        StaticVariables.songfilename);
+                if (!storageAccess.checkFileExtensionValid(uri) && !storageAccess.determineFileTypeByExtension()) {
+                    StaticVariables.myToastMessage = getResources().getString(R.string.file_type_unknown);
+                    ShowToast.showToast(PresenterMode.this);
+                } else {
+                    // Declare we have loaded a new song (for the ccli log).
+                    // This stops us reporting projecting every section
+                    newsongloaded = true;
+
+                    // Send Nearby payload
+                    if (StaticVariables.isHost && StaticVariables.isConnected) {
+                        nearbyConnections.sendSongPayload();
+                    }
+
+                    doCancelAsyncTask(loadsong_async);
+                    loadsong_async = new LoadSong();
+                    try {
+                        loadsong_async.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                    } catch (Exception e) {
+                        // Error loading the song
+                    }
                 }
             }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
     private void findSongInFolders() {
@@ -3588,10 +3597,11 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     // The stuff to deal with the second screen
     @Override
     public void connectHDMI() {
+        StaticVariables.infoBarChangeRequired = true;
         mMediaRouter.addCallback(mMediaRouteSelector, mMediaRouterCallback,
                     MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
         updateDisplays();
-        // IV - Need to refresh fonts/colours when in this mode
+        // IV - Need to refresh all when in this mode
         refreshAll();
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -396,15 +396,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             // Make the drawers match half the width of the screen
             resizeDrawers();
 
-            // Set up the page buttons
-            setupSetButtons();
-
-            // Set up the menus
-            //prepareSongMenu();
-            prepareOptionMenu();
-
-            // Set up the song buttons
-            setupSongButtons();
+            // IV - refreshAll call later will perfoem setupButtons, prepareOptionsMenu and setupSongButtons
 
             // Set up the Wifi service
             getBluetoothName();
@@ -418,13 +410,12 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             // IV - Force display of top level of option menu - needed after mode change
             closeMyDrawers("song");
 
-            // Click on the first item in the set
+            // IV - refreshAll includes load of the song
+            // Click on the first item in the set (which calls refreshAll)
             if (presenter_set_buttonsListView.getChildCount() > 0) {
                 presenter_set_buttonsListView.getChildAt(0).performClick();
-
             } else {
-                // Load the song
-                loadSong();
+                refreshAll();
             }
 
             // Deal with any intents from external files/intents

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -396,7 +396,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             // Make the drawers match half the width of the screen
             resizeDrawers();
 
-            // IV - refreshAll call later will perfoem setupButtons, prepareOptionsMenu and setupSongButtons
+            // IV - refreshAll call later will perform setupButtons, prepareOptionsMenu and setupSongButtons
 
             // Set up the Wifi service
             getBluetoothName();
@@ -766,7 +766,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         prepareStopAutoSlideShow();
 
         try {
-            // Only do this once - if we are the process of loading a song already, don't try to do it again!
+            // Only do this once - if we are in the process of loading a song already, don't try to do it again!
             if (!FullscreenActivity.alreadyloading) {
                 // It will get set back to false in the post execute of the async task
                 FullscreenActivity.alreadyloading = true;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2833,7 +2833,7 @@ public class ProcessSong extends Activity {
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
         drawable.setColor(StaticVariables.transparent);                             // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }
@@ -2860,7 +2860,7 @@ public class ProcessSong extends Activity {
             GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
             drawable.setColor(StaticVariables.transparent);                                    // Makes the box transparent
             if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-                drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+                drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
             } else {
                 drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
             }
@@ -2879,7 +2879,7 @@ public class ProcessSong extends Activity {
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
         drawable.setColor(StaticVariables.transparent);  // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2837,7 +2837,7 @@ public class ProcessSong extends Activity {
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
         drawable.setColor(StaticVariables.transparent);                             // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
+            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }
@@ -2864,7 +2864,7 @@ public class ProcessSong extends Activity {
             GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
             drawable.setColor(StaticVariables.transparent);                                    // Makes the box transparent
             if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-                drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
+                drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
             } else {
                 drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
             }
@@ -2883,7 +2883,7 @@ public class ProcessSong extends Activity {
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
         drawable.setColor(StaticVariables.transparent);  // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and make transparent
+            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -1272,8 +1272,12 @@ public class ProcessSong extends Activity {
                     // IV -   Remove any bold marker, typical word splits, white space and then trim - beautify!
                     bit = bit.replace("B_","").replaceAll("_", "").replaceAll("\\s+-\\s+", "").replaceAll("\\s{2,}", " ").trim();
                     // IV - 2 spaces added to reduce occurance of right edge overrun
-                    // And before so that block text shadow has spaces on both sides
-                    bit = "  " + bit + "  ";
+                    if (StaticVariables.whichMode.equals("Performance")) {
+                        bit = bit + "  ";
+                    } else {
+                        // And before so that block text shadow has spaces on both sides
+                        bit = "  " + bit + "  ";
+                    }
                     // IV - flag used to break loop
                     lyricsOnly = true;
                 } else {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2835,9 +2835,9 @@ public class ProcessSong extends Activity {
         boxbit.setLayoutParams(llp);
         boxbit.setBackgroundResource(R.drawable.lyrics_box);
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
-        drawable.setColor(StaticVariables.transparent);                             // Makes the box transparent
+        drawable.setColor(StaticVariables.transparent); // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and transparent stroke
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }
@@ -2862,9 +2862,9 @@ public class ProcessSong extends Activity {
         } else {
             boxbit.setBackgroundResource(R.drawable.lyrics_box);
             GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
-            drawable.setColor(StaticVariables.transparent);                                    // Makes the box transparent
+            drawable.setColor(StaticVariables.transparent);  // Makes the box transparent
             if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-                drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+                drawable.setStroke(1, StaticVariables.transparent); // set stroke width and transparent stroke
             } else {
                 drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
             }
@@ -2883,7 +2883,7 @@ public class ProcessSong extends Activity {
         GradientDrawable drawable = (GradientDrawable) boxbit.getBackground();
         drawable.setColor(StaticVariables.transparent);  // Makes the box transparent
         if (preferences.getMyPreferenceBoolean(c, "hideLyricsBox", false)) {
-            drawable.setStroke(1, lyricsBackgroundColor); // set stroke width and stroke color
+            drawable.setStroke(1, StaticVariables.transparent); // set stroke width and transparent stroke
         } else {
             drawable.setStroke(1, lyricsTextColor); // set stroke width and stroke color
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2628,11 +2628,14 @@ public class ProcessSong extends Activity {
             }
             ll.addView(tl);
         }
-        TextView emptyline = new TextView(c);
-        emptyline.setLayoutParams(linearlayout_params());
-        emptyline.setText(" ");
-        emptyline.setTextSize(fontsize * 0.5f);
-        ll.addView(emptyline);
+        // IV - Add empty line only for multi section performance mode
+        if (StaticVariables.whichMode.equals("Performance")) {
+            TextView emptyline = new TextView(c);
+            emptyline.setLayoutParams(linearlayout_params());
+            emptyline.setText(" ");
+            emptyline.setTextSize(fontsize * 0.5f);
+            ll.addView(emptyline);
+        }
         return ll;
     }
 
@@ -2848,7 +2851,7 @@ public class ProcessSong extends Activity {
         if (StaticVariables.whichMode.equals("Presentation") || StaticVariables.whichMode.equals("Stage")) {
             boxbit.setGravity(Gravity.CENTER_VERTICAL);
         }
-        if (StaticVariables.whichMode.equals("Presentation")) {
+        if (StaticVariables.whichMode.equals("Presentation") || (StaticVariables.whichMode.equals("Stage") && !(preferences.getMyPreferenceBoolean(c, "presoShowChords", false)))) {
             boxbit.setBackground(null);
             boxbit.setHorizontalGravity(preferences.getMyPreferenceInt(c, "presoLyricsAlign", Gravity.CENTER_HORIZONTAL));
             boxbit.setVerticalGravity(preferences.getMyPreferenceInt(c, "presoLyricsVAlign", Gravity.CENTER_VERTICAL));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -523,18 +523,12 @@ public class StageMode extends AppCompatActivity implements
                 // Restore Drawer Swipe preference
                 toggleDrawerSwipe();
 
-                // Prepare the song menu
-                prepareSongMenu();
-
-                // Prepare the MAIN option menu
+                // IV - RefreshAll calls setupButtons, prepareOptionsMenu and setupSongButtons
+                // Start with MAIN option menu
                 StaticVariables.whichOptionMenu="MAIN";
-                prepareOptionMenu();
-
-                // Set up the page buttons
-                setupPageButtons();
 
                 // Load the song and get started
-                loadSong();
+                refreshAll();
 
                 // Prepare abhide listener
                 setupAbHide();
@@ -6761,6 +6755,10 @@ public class StageMode extends AppCompatActivity implements
                 // It will get set back to false in the post execute of the async task
                 FullscreenActivity.alreadyloading = true;
 
+                // IV - Set presenting options
+                StaticVariables.panicRequired = false;
+                StaticVariables.infoBarChangeRequired = true;
+
                 // Clear any queued 'after song display' activity - we are moving to a new song
                 startCapoAnimationHandler.removeCallbacks(startCapoAnimationRunnable);
                 startAutoscrollHandler.removeCallbacks(startAutoscrollRunnable);
@@ -8211,6 +8209,7 @@ public class StageMode extends AppCompatActivity implements
     // The stuff to deal with the second screen
     @Override
     public void connectHDMI() {
+        StaticVariables.infoBarChangeRequired = true;
         mMediaRouter.addCallback(mMediaRouteSelector, mMediaRouterCallback,
                 MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
         updateDisplays();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -6750,7 +6750,7 @@ public class StageMode extends AppCompatActivity implements
     @Override
     public void loadSong() {
         try {
-            // Only do this once - if we are the process of loading a song already, don't try to do it again!
+            // Only do this once - if we are in the process of loading a song already, don't try to do it again!
             if (!FullscreenActivity.alreadyloading) {
                 // It will get set back to false in the post execute of the async task
                 FullscreenActivity.alreadyloading = true;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -3448,10 +3448,10 @@ public class StageMode extends AppCompatActivity implements
             StaticVariables.myToastMessage = getString(R.string.switchtoperformmode);
             ShowToast.showToast(StageMode.this);
         } else {
+            FullscreenActivity.bmScreen = null;
             if (StaticVariables.thisSongScale == null || !StaticVariables.thisSongScale.equals("Y")) {
                 StaticVariables.myToastMessage = getString(R.string.highlight_notallowed);
                 ShowToast.showToast(StageMode.this);
-                FullscreenActivity.bmScreen = null;
             } else {
                 boolean vis = false;
                 if (highlightNotes != null && highlightNotes.getVisibility() == View.VISIBLE) {
@@ -3465,7 +3465,7 @@ public class StageMode extends AppCompatActivity implements
                     glideimage_ScrollView.destroyDrawingCache();
                     glideimage_ScrollView.setDrawingCacheEnabled(true);
                     glideimage_ScrollView.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_LOW);
-                    FullscreenActivity.bmScreen = null;
+                    glideimage_ScrollView.setDrawingCacheBackgroundColor(lyricsBackgroundColor);
                     try {
                         FullscreenActivity.bmScreen = glideimage_ScrollView.getDrawingCache().copy(Bitmap.Config.ARGB_8888, true);
                     } catch (Exception e) {
@@ -3478,7 +3478,7 @@ public class StageMode extends AppCompatActivity implements
                     songscrollview.destroyDrawingCache();
                     songscrollview.setDrawingCacheEnabled(true);
                     songscrollview.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_LOW);
-                    FullscreenActivity.bmScreen = null;
+                    songscrollview.setDrawingCacheBackgroundColor(lyricsBackgroundColor);
                     try {
                         FullscreenActivity.bmScreen = songscrollview.getDrawingCache().copy(Bitmap.Config.ARGB_8888, true);
                     } catch (Exception e) {
@@ -4958,7 +4958,19 @@ public class StageMode extends AppCompatActivity implements
 
                 Canvas canvas = new Canvas(FullscreenActivity.bmScreen);
                 canvas.scale(scale,scale);
+                songscrollview.setBackgroundColor(lyricsBackgroundColor);
                 songscrollview.getChildAt(0).draw(canvas);
+                songscrollview.destroyDrawingCache();
+                songscrollview.setDrawingCacheEnabled(true);
+                songscrollview.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_LOW);
+                songscrollview.setDrawingCacheBackgroundColor(lyricsBackgroundColor);
+                try {
+                    FullscreenActivity.bmScreen = songscrollview.getDrawingCache().copy(Bitmap.Config.ARGB_8888, true);
+                } catch (Exception e) {
+                    Log.d("StageMode", "ShareSong error getting the screenshot!");
+                } catch (OutOfMemoryError o) {
+                    Log.d("StageMode", "ShareSong Out of memory");
+                }
 
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/res/layout/cast_screen.xml
+++ b/app/src/main/res/layout/cast_screen.xml
@@ -73,7 +73,7 @@
                 android:paddingTop="8dp"
                 android:paddingRight="24dp"
                 android:paddingBottom="8dp"
-                android:visibility="visible"
+                android:visibility="gone"
                 android:drawableStart="@mipmap/ic_round_launcher" />
 
             <LinearLayout
@@ -85,7 +85,7 @@
                 android:paddingEnd="24dp"
                 android:paddingStart="24dp"
                 android:paddingBottom="8dp"
-                android:visibility="visible">
+                android:visibility="gone">
 
                 <TextView
                     android:id="@+id/presentermode_title"
@@ -128,9 +128,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/col1_2"
@@ -139,9 +141,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/col2_2"
@@ -150,9 +154,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/col1_3"
@@ -161,9 +167,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/col2_3"
@@ -172,9 +180,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/col3_3"
@@ -183,9 +193,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:visibility="invisible" />
+        android:visibility="gone" />
 
     <ImageView
         android:id="@+id/projected_Logo"

--- a/app/src/main/res/layout/cast_screen.xml
+++ b/app/src/main/res/layout/cast_screen.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout android:id="@+id/projectedPage_RelativeLayout"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/projectedPage_RelativeLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:background="#000">
 
     <RelativeLayout
         android:id="@+id/pageHolder"
@@ -14,31 +14,29 @@
         android:layout_centerInParent="true"
         tools:ignore="UselessParent">
 
-    <ImageView
-        android:id="@+id/projected_BackgroundImage"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_centerInParent="true"
-        android:scaleType="centerCrop"
-        android:contentDescription="@string/app_name"
-        android:visibility="invisible"/>
+        <ImageView
+            android:id="@+id/projected_BackgroundImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:contentDescription="@string/app_name"
+            android:scaleType="centerCrop"
+            android:visibility="invisible" />
 
         <SurfaceView
             android:id="@+id/projected_SurfaceView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_centerInParent="true"
-            android:layout_margin="0dp"
-            android:padding="0dp"
             android:visibility="invisible" />
 
-    <ImageView
-        android:id="@+id/projected_ImageView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_centerInParent="true"
-        android:contentDescription="@string/app_name"
-        android:visibility="invisible"/>
+        <ImageView
+            android:id="@+id/projected_ImageView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:contentDescription="@string/app_name"
+            android:visibility="invisible" />
 
         <LinearLayout
             android:id="@+id/projected_LinearLayout"
@@ -51,7 +49,6 @@
             android:orientation="vertical"
             android:visibility="visible" />
 
-
         <LinearLayout
             android:id="@+id/bottom_infobar"
             android:layout_width="match_parent"
@@ -59,31 +56,14 @@
             android:layout_alignParentBottom="true"
             android:orientation="horizontal">
 
-
-            <TextView
-                android:id="@+id/songinfo_TextView"
-                style="@style/MyWhiteHeadingText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_margin="0dp"
-                android:drawablePadding="12dp"
-                android:gravity="center_vertical"
-                android:paddingLeft="24dp"
-                android:paddingTop="8dp"
-                android:paddingRight="24dp"
-                android:paddingBottom="8dp"
-                android:visibility="gone"
-                android:drawableStart="@mipmap/ic_round_launcher" />
-
             <LinearLayout
                 android:id="@+id/presentermode_bottombit"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
+                android:paddingStart="24dp"
                 android:paddingTop="4dp"
                 android:paddingEnd="24dp"
-                android:paddingStart="24dp"
                 android:paddingBottom="8dp"
                 android:visibility="gone">
 
@@ -116,96 +96,97 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:includeFontPadding="false" />
+
             </LinearLayout>
+
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/col1_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
+        <LinearLayout
+            android:id="@+id/col1_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
-    <LinearLayout
-        android:id="@+id/col1_1"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        <LinearLayout
+            android:id="@+id/col2_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
-    <LinearLayout
-        android:id="@+id/col1_2"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        <LinearLayout
+            android:id="@+id/col1_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
-    <LinearLayout
-        android:id="@+id/col2_2"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        <LinearLayout
+            android:id="@+id/col2_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
-    <LinearLayout
-        android:id="@+id/col1_3"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        <LinearLayout
+            android:id="@+id/col3_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
-    <LinearLayout
-        android:id="@+id/col2_3"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
-
-    <LinearLayout
-        android:id="@+id/col3_3"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/projected_Logo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ost_logo"
-        android:layout_centerInParent="true"
-        android:contentDescription="@string/app_name" />
+        <ImageView
+            android:id="@+id/projected_Logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:contentDescription="@string/app_name"
+            android:src="@drawable/ost_logo"
+            android:visibility="gone" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/popup_layout.xml
+++ b/app/src/main/res/layout/popup_layout.xml
@@ -114,7 +114,7 @@
             <LinearLayout
                 android:id="@+id/group_manualfontsize"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:orientation="vertical">
 
                 <TextView
@@ -129,23 +129,23 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                <SeekBar
-                    android:id="@+id/setFontSizeProgressBar"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="8dp"
-                    android:background="@drawable/apptheme_scrubber_primary_holo"
-                    android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
-                    android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright"  />
+                    <SeekBar
+                        android:id="@+id/setFontSizeProgressBar"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        android:background="@drawable/apptheme_scrubber_primary_holo"
+                        android:progressDrawable="@drawable/apptheme_scrubber_secondary_holo"
+                        android:thumb="@drawable/apptheme_scrubber_control_normal_holo_bright" />
 
-                <TextView
-                    android:id="@+id/fontSizePreview"
-                    style="@style/MyInfoText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="100dp"
-                    android:layout_gravity="center_horizontal|top" />
+                    <TextView
+                        android:id="@+id/fontSizePreview"
+                        style="@style/MyInfoText"
+                        android:layout_width="wrap_content"
+                        android:layout_height="100dp"
+                        android:layout_gravity="center_horizontal|top" />
 
-            </LinearLayout>
+                </LinearLayout>
 
             </LinearLayout>
 
@@ -490,6 +490,7 @@
                     android:thumb="@drawable/apptheme_scrubber_control_normal_holo" />
 
                 <TextView
+                    android:id="@+id/presoAlertText"
                     style="@style/MyHeadingText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Hello Gareth,

This moves to using the 'Presentation' presentation info for all modes.  A positive (I think) side effect is that backgrounds can now be used in all modes.

Further options for presentation info we might consider are:
1. Background colour opacity (0 being OFF)
2. Autohide ON/OFF

These would give a user the ability to re-establish the old song info. No background colour, autohide OFF and set copyright info size to 0. No logo though!

Please consider.

Kind regards
Ian V
