### PR TITLE
Major update to Nearby section change handling

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/LoadXML.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/LoadXML.java
@@ -326,7 +326,7 @@ public class LoadXML extends Activity {
         StaticVariables.thisSongScale = preferences.getMyPreferenceString(c,"songAutoScale","W");
 
         // IV - When an error force use of section 0
-        if (FullscreenActivity.myLyrics == c.getString(R.string.user_guide_lyrics)) {
+        if (FullscreenActivity.isSong && FullscreenActivity.myLyrics == c.getString(R.string.user_guide_lyrics)) {
             StaticVariables.currentSection = 0;
             FullscreenActivity.pdfPageCurrent = 0;
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/LoadXML.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/LoadXML.java
@@ -324,6 +324,12 @@ public class LoadXML extends Activity {
         }
 
         StaticVariables.thisSongScale = preferences.getMyPreferenceString(c,"songAutoScale","W");
+
+        // IV - When an error force use of section 0
+        if (FullscreenActivity.myLyrics == c.getString(R.string.user_guide_lyrics)) {
+            StaticVariables.currentSection = 0;
+            FullscreenActivity.pdfPageCurrent = 0;
+        }
     }
 
     private static void updateNonOpenSongDetails(NonOpenSongSQLite nonOpenSongSQLite) {
@@ -376,16 +382,17 @@ public class LoadXML extends Activity {
     }
 
     private static void setNotFound(Context c) {
-        FullscreenActivity.myLyrics = StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "\n\n" +
+        // IV - Prepared as a single section
+        FullscreenActivity.myLyrics = "[" + StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "]\n\n _ \n " +
                 c.getResources().getString(R.string.songdoesntexist) + "\n\n";
-        StaticVariables.mLyrics = StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "\n\n" +
+        StaticVariables.mLyrics = "[" + StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "]\n\n _ \n " +
                 c.getResources().getString(R.string.songdoesntexist) + "\n\n";
         FullscreenActivity.myXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<title>Welcome to OpenSongApp</title>\n" +
                 "<author>Gareth Evans</author>\n<lyrics>"
-                + StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "\n\n"
+                + "[" + StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "]\n\n _\n "
                 + c.getResources().getString(R.string.songdoesntexist) + "\n\n" + "</lyrics>";
-        StaticVariables.mLyrics = StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "\n\n"
+        StaticVariables.mLyrics = "[" + StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename + "]\n\n _\n "
                 + c.getResources().getString(R.string.songdoesntexist) + "\n\n";
         FullscreenActivity.myLyrics = "ERROR!";
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -62,6 +62,8 @@ public class NearbyConnections implements NearbyInterface {
     private String payLoadTransferIds = "";
     private String latestfoldernamepair = "";
 
+    private int pendingCurrentSection = 0;
+
     NearbyConnections(Context context, Preferences preferences, StorageAccess storageAccess,
                       ProcessSong processSong, OptionMenuListeners optionMenuListeners,
                       SQLiteHelper sqLiteHelper) {
@@ -413,6 +415,10 @@ public class NearbyConnections implements NearbyInterface {
 
         // IV - Process each end point - we need a unique ParcelFileDescriptor if a file is sent
         for (String endpointId : connectedEndPoints) {
+            // IV - Send current section as a pending section change (-ve offset by 1) for use by CLIENT song load
+            infoPayload = "___section___-" + (1 + StaticVariables.currentSection);
+            Nearby.getConnectionsClient(context).sendPayload(endpointId, Payload.fromBytes(infoPayload.getBytes()));
+
             infoPayload = null;
             if (FullscreenActivity.isSong) {
                 // By default, this should be smaller than 32kb, so probably going to send as bytes
@@ -456,7 +462,6 @@ public class NearbyConnections implements NearbyInterface {
                 }
             }
         }
-
         return largePayLoad;
     }
     @Override
@@ -478,14 +483,28 @@ public class NearbyConnections implements NearbyInterface {
     }
     private void payloadSection(String incoming) {
         if (!StaticVariables.whichMode.equals("Performance")) {
+            //Log.d("NearbyConnections", "pendingCurrentSection In " + pendingCurrentSection);
             int mysection = processSong.getNearbySection(incoming);
+            //Log.d("NearbyConnections", "mysection " + mysection);
             if (mysection >= 0) {
-                if (nearbyReturnActionsInterface != null) {
-                    // Look for a section being sent
-                    StaticVariables.currentSection = mysection;
-                    nearbyReturnActionsInterface.selectSection(mysection);
+                if (pendingCurrentSection < 0) {
+                    // IV - A song load is pending - 'Store' the section change (-ve offset by 1) for use by song load
+                    pendingCurrentSection = -(1 + mysection);
+                } else {
+                    if (StaticVariables.currentSection != mysection &&
+                        nearbyReturnActionsInterface != null) {
+                        // IV - Do the section change
+                        StaticVariables.currentSection = mysection;
+                        if (!FullscreenActivity.alreadyloading) {
+                            nearbyReturnActionsInterface.selectSection(mysection);
+                        }
+                    }
                 }
+            } else {
+                // IV - A Host has passed a section directly into pending state ready for a following song load
+                pendingCurrentSection = mysection;
             }
+            //Log.d("NearbyConnections", "pendingCurrentSection Out " + pendingCurrentSection);
         }
     }
     private void payloadOpenSong(String incoming) {
@@ -526,7 +545,6 @@ public class NearbyConnections implements NearbyInterface {
                         StaticVariables.songfilename = receivedBits.get(1);
                         // Add to the sqldatabase
                         sqLiteHelper.createSong(context, StaticVariables.whichSongFolder, StaticVariables.songfilename);
-
                     } else {
                         newLocation = storageAccess.getUriForItem(context, preferences, "Received", "", "ReceivedSong");
                         // Prepare the output stream in the Received folder - just keep a temporary version
@@ -542,6 +560,7 @@ public class NearbyConnections implements NearbyInterface {
                     if (nearbyReturnActionsInterface != null) {
                         storageAccess.writeFileFromString(receivedBits.get(3), outputStream);
                         nearbyReturnActionsInterface.prepareSongMenu();
+                        StaticVariables.currentSection = pendingCurrentSection;
                         nearbyReturnActionsInterface.loadSong();
                     }
                 } else if (!StaticVariables.isHost && StaticVariables.isConnected) {
@@ -553,6 +572,7 @@ public class NearbyConnections implements NearbyInterface {
 
                     // Now load the song
                     if (nearbyReturnActionsInterface != null) {
+                        StaticVariables.currentSection = pendingCurrentSection;
                         nearbyReturnActionsInterface.loadSong();
                     }
                 }
@@ -561,6 +581,8 @@ public class NearbyConnections implements NearbyInterface {
         } else {
             Log.d("NearbyConnections", "payloadOpenSong - no change as unchanged payload");
         }
+        // IV - 0 is no pending
+        pendingCurrentSection = 0;
     }
     private void payloadFile(Payload payload, String foldernamepair) {
         // IV - CLIENT: Cancel previous song transfers - a new song has arrived
@@ -579,6 +601,7 @@ public class NearbyConnections implements NearbyInterface {
             movepage = true;
         } else {
             FullscreenActivity.pdfPageCurrent = 0;
+            StaticVariables.currentSection = 0;
         }
         Uri newLocation = null;
         if (!StaticVariables.isHost && StaticVariables.isConnected && StaticVariables.receiveHostFiles && StaticVariables.keepHostFiles) {
@@ -612,7 +635,10 @@ public class NearbyConnections implements NearbyInterface {
             OutputStream outputStream = storageAccess.getOutputStream(context, newLocation);
             if (storageAccess.copyFile(inputStream, outputStream)) {
                 if (nearbyReturnActionsInterface != null) {
+                    StaticVariables.currentSection = pendingCurrentSection;
                     nearbyReturnActionsInterface.loadSong();
+                    // IV - End pending
+                    pendingCurrentSection = 0;
                 }
             }
             Log.d("NearbyConnections", "originalUri=" + originalUri);
@@ -625,7 +651,10 @@ public class NearbyConnections implements NearbyInterface {
             }
         } else {
             if (nearbyReturnActionsInterface != null) {
+                StaticVariables.currentSection = pendingCurrentSection;
                 nearbyReturnActionsInterface.loadSong();
+                // IV - End pending
+                pendingCurrentSection = 0;
             }
         }
     }
@@ -679,6 +708,7 @@ public class NearbyConnections implements NearbyInterface {
                             } else if (incoming.contains("autoscroll_")) {
                                 payloadAutoscroll(incoming);
                             } else if (incoming.contains("___section___")) {
+                                //Log.d("NearbyConnections", "Section " + incoming);
                                 payloadSection(incoming);
                             } else if (incoming.contains("_ep__ep_")) {
                                 payloadEndpoints(incoming);
@@ -699,8 +729,10 @@ public class NearbyConnections implements NearbyInterface {
             public void onPayloadTransferUpdate(@NonNull String s, @NonNull PayloadTransferUpdate payloadTransferUpdate) {
                 // IV - If we are a client and not 'receiving host files' then cancel these uneeded FILE transfers
                 if (!StaticVariables.isHost && !StaticVariables.receiveHostFiles) {
-                    Log.d("NearbyConnections", "Cancelled Id " + payloadTransferUpdate.getPayloadId());
-                    Nearby.getConnectionsClient(context).cancelPayload(payloadTransferUpdate.getPayloadId());
+                    if (incomingFilePayloads.containsKey(payloadTransferUpdate.getPayloadId())) {
+                        Log.d("NearbyConnections", "Cancelled Id " + payloadTransferUpdate.getPayloadId());
+                        Nearby.getConnectionsClient(context).cancelPayload(payloadTransferUpdate.getPayloadId());
+                    }
                 } else {
                     if (payloadTransferUpdate.getStatus() == PayloadTransferUpdate.Status.SUCCESS) {
                         // For bytes this is sent automatically, but it's the file we are interested in here

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -121,30 +121,33 @@ public class NearbyConnections implements NearbyInterface {
     }
     @Override
     public void startDiscovery() {
-        Log.d("NearbyConnections", "startDiscovery()");
-        if (!isDiscovering) {
-            Nearby.getConnectionsClient(context)
-                    .startDiscovery(serviceId, endpointDiscoveryCallback(), discoveryOptions)
-                    .addOnSuccessListener(
-                            (Void unused) -> {
-                                // We're discovering!
-                                updateConnectionLog(context.getResources().getString(R.string.connections_discover));
-                                isDiscovering = true;
-                                Log.d("NearbyConnections", "startDiscovery() - success");
-                            })
-                    .addOnFailureListener(
-                            (Exception e) -> {
-                                // We're unable to start discovering.
-                                stopDiscovery();
-                                Log.d("NearbyConnections", "startDiscovery() - failure: " + e);
-                            });
-        } else {
-            Log.d("NearbyConnections", "startDiscovery() - already discovering");
-        }
-        // IV - Stop 30s after this (latest) call
-        if (isDiscovering) {
-            stopDiscoveryHandler.removeCallbacks(stopDiscoveryRunnable);
-            stopDiscoveryHandler.postDelayed(stopDiscoveryRunnable, 30000);
+        // IV - Only if still in use
+        if (StaticVariables.usingNearby) {
+            Log.d("NearbyConnections", "startDiscovery()");
+            if (!isDiscovering) {
+                Nearby.getConnectionsClient(context)
+                        .startDiscovery(serviceId, endpointDiscoveryCallback(), discoveryOptions)
+                        .addOnSuccessListener(
+                                (Void unused) -> {
+                                    // We're discovering!
+                                    updateConnectionLog(context.getResources().getString(R.string.connections_discover));
+                                    isDiscovering = true;
+                                    Log.d("NearbyConnections", "startDiscovery() - success");
+                                })
+                        .addOnFailureListener(
+                                (Exception e) -> {
+                                    // We're unable to start discovering.
+                                    stopDiscovery();
+                                    Log.d("NearbyConnections", "startDiscovery() - failure: " + e);
+                                });
+            } else {
+                Log.d("NearbyConnections", "startDiscovery() - already discovering");
+            }
+            // IV - Stop 30s after this (latest) call
+            if (isDiscovering) {
+                stopDiscoveryHandler.removeCallbacks(stopDiscoveryRunnable);
+                stopDiscoveryHandler.postDelayed(stopDiscoveryRunnable, 30000);
+            }
         }
     }
     @Override
@@ -304,7 +307,10 @@ public class NearbyConnections implements NearbyInterface {
                 connectedEndPoints.remove(endpointId);
                 String deviceName = getDeviceNameFromId(endpointId);
                 connectedEndPointsNames.remove(endpointId + "__" + deviceName);
-                updateConnectionLog(context.getResources().getString(R.string.connections_disconnect) + " " + deviceName);
+                // IV - Only if still in use
+                if (StaticVariables.usingNearby) {
+                    updateConnectionLog(context.getResources().getString(R.string.connections_disconnect) + " " + deviceName);
+                }
 
                 if (StaticVariables.isHost) {
                     // Check if we have valid connections

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -1803,8 +1803,6 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                 StaticVariables.usingNearby = false;
                 hostOptions.setVisibility(View.GONE);
                 clientOptions.setVisibility(View.GONE);
-                nearbyInterface.stopDiscovery();
-                nearbyInterface.stopAdvertising();
                 nearbyInterface.turnOffNearby();
             }
         });

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -1520,8 +1520,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                 }
             }
         }
-        // Select the first button if we can
-        StaticVariables.currentSection = 0;
+        // Select the current button if we can
         selectSectionButtonInSong(StaticVariables.currentSection);
     }
 
@@ -2127,6 +2126,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             // If this is an image, hide the text, show the image, otherwise show the text in the slide window
             if (FullscreenActivity.isPDF) {
                 FullscreenActivity.pdfPageCurrent = which;
+                StaticVariables.currentSection = which;
                 loadPDFPagePreview();
             } else if (FullscreenActivity.isImage) {
                 StaticVariables.uriToLoad = storageAccess.getUriForItem(PresenterMode.this, preferences, "Songs", StaticVariables.whichSongFolder, StaticVariables.songfilename);
@@ -2644,6 +2644,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     public void changePDFPage(int page, String direction) {
         FullscreenActivity.whichDirection = direction;
         FullscreenActivity.pdfPageCurrent = page;
+        StaticVariables.currentSection = page;
         if (presenter_song_buttonsListView.getChildCount()>page) {
             LinearLayout row = (LinearLayout) presenter_song_buttonsListView.getChildAt(page);
             Button thisbutton = (Button) row.getChildAt(1);
@@ -3381,6 +3382,14 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                             h.post(() -> ShowToast.showToast(PresenterMode.this));
                         }
                     }
+                    // IV - Set current values
+                    if (StaticVariables.currentSection >= 0) {
+                        StaticVariables.currentSection = 0;
+                    } else {
+                        // IV - Consume any pending client section change received from Host (-ve value)
+                        StaticVariables.currentSection = -(1 + StaticVariables.currentSection);
+                    }
+                    FullscreenActivity.pdfPageCurrent = StaticVariables.currentSection;
                 }
 
                 // Clear the old headings (presention order looks for these)
@@ -3507,6 +3516,12 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         unhighlightAllSetButtons();
                     }
                     showCorrectViews();
+
+                    // IV - Consume any later pending client section change received from Host (-ve value)
+                    if (StaticVariables.currentSection < 0) {
+                        StaticVariables.currentSection = -(1 + StaticVariables.currentSection);
+                    }
+
                     if (FullscreenActivity.isPDF) {
                         LoadXML.getPDFPageCount(PresenterMode.this, preferences, storageAccess);
                     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -1281,6 +1281,8 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         });
     }
     private void showCorrectViews() {
+        // IV - Make sure it starts clear
+        presenter_lyrics_image.setImageBitmap(null);
         if (FullscreenActivity.isImage || FullscreenActivity.isPDF) {
             // Image and PDF files replace the slide text with an image preview
             presenter_lyrics_image.setVisibility(View.VISIBLE);
@@ -1759,8 +1761,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     private void loadImagePreview() {
         // Make the appropriate bits visible
         presenter_lyrics.setVisibility(View.GONE);
-        // IV - Make sure it starts clear
-        presenter_lyrics_image.setImageBitmap(null);
 
         // Process the image location into an URI, then get the sizes
         BitmapFactory.Options options = new BitmapFactory.Options();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2723,6 +2723,8 @@ public class ProcessSong extends Activity {
                 mCurrentPage = mPdfRenderer.openPage(FullscreenActivity.pdfPageCurrent);
             }
 
+            StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
+
             // Get pdf size from page
             int pdfwidth;
             int pdfheight;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -2712,6 +2712,11 @@ public class ProcessSong extends Activity {
                 }
             }
 
+            if (mFileDescriptor == null) {
+                // IV - No file
+                return null;
+            }
+
             // Open page 0
             PdfRenderer.Page mCurrentPage = null;
             if (mPdfRenderer != null) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/SongMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/SongMenuListeners.java
@@ -31,8 +31,6 @@ public class SongMenuListeners extends Activity {
         final String whichSongFolder = StaticVariables.whichSongFolder;
 
         return v -> {
-            FullscreenActivity.pdfPageCurrent = 0;
-
             try {
                 if (clickedkey.equals(c.getString(R.string.songsinfolder))) {
                     // We clicked on a folder

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -1452,6 +1452,12 @@ public class StageMode extends AppCompatActivity implements
         }
     }
 
+    private void sendSongSectionForPendingToConnected() {
+        // IV - Send a pending section change to the client (-ve offset by 1)
+        String infoPayload = "___section___-" + (1 + StaticVariables.currentSection);
+        nearbyConnections.doSendPayloadBytes(infoPayload);
+    }
+
     @Override
     public void shareSong() {
         doCancelAsyncTask(sharesong_async);
@@ -2147,9 +2153,9 @@ public class StageMode extends AppCompatActivity implements
         if (!FullscreenActivity.alreadyloading) {
             if (FullscreenActivity.isPDF && !checkCanScrollUp() && (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0)) {
                 FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent - 1;
+                StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
                 // Send page number as 'section' to other devices
                 if (StaticVariables.whichMode.equals("Stage") && StaticVariables.isHost && StaticVariables.isConnected) {
-                    StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
                     sendSongSectionToConnected();
                 }
                 // IV - Indicate reload which does not impact running pad etc.
@@ -2218,9 +2224,9 @@ public class StageMode extends AppCompatActivity implements
         if (!FullscreenActivity.alreadyloading) {
             if (FullscreenActivity.isPDF && !checkCanScrollDown() && (FullscreenActivity.pdfPageCurrent < (FullscreenActivity.pdfPageCount - 1))) {
                 FullscreenActivity.pdfPageCurrent = FullscreenActivity.pdfPageCurrent + 1;
+                StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
                 // Send page number as 'section' to other devices
                 if (StaticVariables.whichMode.equals("Stage") && StaticVariables.isHost && StaticVariables.isConnected) {
-                    StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
                     sendSongSectionToConnected();
                 }
                 // IV - Indicate reload which does not impact running pad etc.
@@ -3458,7 +3464,6 @@ public class StageMode extends AppCompatActivity implements
         if (!FullscreenActivity.alreadyloading) {
             FullscreenActivity.whichDirection = "R2L";
             StaticVariables.showstartofpdf = true;
-            FullscreenActivity.pdfPageCurrent = 0;
             // IV - PDF page move handling moved to doscrollDown
             if (StaticVariables.setView) {
                 // Is there another song in the set?  If so move, if not, do nothing
@@ -3829,6 +3834,11 @@ public class StageMode extends AppCompatActivity implements
             }
         }
 
+        // IV - Consume any later pending client section change received from Host (-ve value)
+        if (StaticVariables.currentSection < 0) {
+            StaticVariables.currentSection = -(1 + StaticVariables.currentSection);
+        }
+
         // IV - If StaticVariables.metronomeonoff == "on" this is a reload with the Metronome left running
         // For all other case loadSong has stopped any running Metronome task == "off"
         if (StaticVariables.metronomeonoff == "off") {
@@ -3871,6 +3881,7 @@ public class StageMode extends AppCompatActivity implements
             glideimage.getViewTreeObserver().addOnGlobalLayoutListener(vto);
 
         } else {
+            final int proposedCurrentSection = StaticVariables.currentSection;
             final LinearLayout songbit = (LinearLayout) songscrollview.getChildAt(0);
             songbit.postDelayed(() -> {
                 songwidth = songbit.getMeasuredWidth();
@@ -3879,10 +3890,19 @@ public class StageMode extends AppCompatActivity implements
                 songbit.setScaleY(1.0f);
                 highlightNotes.setScaleX(1.0f);
                 highlightNotes.setScaleY(1.0f);
+                // Scroll to show this view at the top of the page unless we are autoscrolling
+                try {
+                    FullscreenActivity.sectionviews[StaticVariables.currentSection].setAlpha(1.0f);
+                    if (!StaticVariables.isautoscrolling &&
+                            (proposedCurrentSection == StaticVariables.currentSection)) {
+                        songscrollview.smoothScrollTo(0, FullscreenActivity.sectionviews[StaticVariables.currentSection].getTop() - (int) (getAvailableHeight() * (1.0f - preferences.getMyPreferenceFloat(StageMode.this, "scrollDistance", 0.7f))));
+                    }
+                } catch (Exception e) {
+                    Log.d(TAG, "Section not found");
+                }
             }, 1000);
         }
 
-        songscrollview.scrollTo(0,0);
         glideimage_ScrollView.scrollTo(0,0);
         FullscreenActivity.newPosFloat = 0.0f;
         // Automatically start the autoscroll
@@ -4080,6 +4100,7 @@ public class StageMode extends AppCompatActivity implements
 
     @Override
     public void selectSection(int whichone) {
+        //Log.d("StageMode","selectSection " + whichone);
         if (FullscreenActivity.isPDF) {
             // IV - 'Section' moves for PDF will arrive from presenter mode and Stage mode PDF page moves
             // IV - A connected host may request an invalid section, if it does show section 0
@@ -4091,6 +4112,7 @@ public class StageMode extends AppCompatActivity implements
                 whichone = 0;
             }
 
+            StaticVariables.currentSection = whichone;
             FullscreenActivity.pdfPageCurrent = whichone;
 
             // Send section to other devices
@@ -4111,40 +4133,40 @@ public class StageMode extends AppCompatActivity implements
                 whichone = 0;
             }
 
-            StaticVariables.currentSection = whichone;
-
-            // Send section to other devices
-            if (StaticVariables.isHost && StaticVariables.isConnected && FullscreenActivity.isSong) {
-                sendSongSectionToConnected();
-            }
-
-            // Set this sections alpha to 1.0f;
-            try {
-                FullscreenActivity.sectionviews[whichone].setAlpha(1.0f);
-            } catch (Exception e) {
-                Log.d(TAG, "Section not found");
-            }
-
             // Smooth scroll to show this view at the top of the page unless we are autoscrolling
             try {
+                if (FullscreenActivity.sectionviews[whichone] == null) {
+                    Log.d("StageMode","Had to reset section to 0");
+                    whichone = 0;
+                }
                 if (!StaticVariables.isautoscrolling) {
                     songscrollview.smoothScrollTo(0, FullscreenActivity.sectionviews[whichone].getTop() - (int) (getAvailableHeight() * (1.0f - preferences.getMyPreferenceFloat(StageMode.this, "scrollDistance", 0.7f))));
                 }
             } catch (Exception e) {
+                whichone = 0;
                 Log.d(TAG, "Section not found");
             }
 
             try {
-                // Go through each of the views and set the alpha of the others to 0.5f;
-                for (int x = 0; x < FullscreenActivity.sectionviews.length; x++) {
-                    if (x != whichone) {
-                        FullscreenActivity.sectionviews[x].setAlpha(0.5f);
+                if (FullscreenActivity.sectionviews[whichone] != null) {
+                    // Go through each of the views and set the alpha (deliberatly all are set)
+                    for (int x = 0; x < FullscreenActivity.sectionviews.length; x++) {
+                        if (x == whichone) {
+                            FullscreenActivity.sectionviews[x].setAlpha(1.0f);
+                        } else {
+                            FullscreenActivity.sectionviews[x].setAlpha(0.5f);
+                        }
                     }
+                    FullscreenActivity.tempswipeSet = "enable";
+                    StaticVariables.setMoveDirection = "";
+                    StaticVariables.currentSection = whichone;
+                    FullscreenActivity.pdfPageCurrent = whichone;
+                    // Send section to other devices
+                    if (StaticVariables.isHost && StaticVariables.isConnected && FullscreenActivity.isSong) {
+                        sendSongSectionToConnected();
+                    }
+                    dualScreenWork();
                 }
-                FullscreenActivity.tempswipeSet = "enable";
-                StaticVariables.setMoveDirection = "";
-
-                dualScreenWork();
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -5959,7 +5981,6 @@ public class StageMode extends AppCompatActivity implements
                 mypage.setBackgroundColor(lyricsBackgroundColor);
                 songscrollview.setBackgroundColor(lyricsBackgroundColor);
                 width_scale = 0f;
-                StaticVariables.currentSection = 0;
                 testpane.removeAllViews();
                 testpane1_2.removeAllViews();
                 testpane2_2.removeAllViews();
@@ -6205,10 +6226,10 @@ public class StageMode extends AppCompatActivity implements
                     songscrollview.removeAllViews();
                     songbit.addView(column1_1);
                     songscrollview.addView(songbit);
-                    if (FullscreenActivity.sectionviews[0] != null) {
+                    if (FullscreenActivity.sectionviews[StaticVariables.currentSection] != null) {
                         // Make the first section active (full alpha)
                         try {
-                            FullscreenActivity.sectionviews[0].setAlpha(1.0f);
+                            FullscreenActivity.sectionviews[StaticVariables.currentSection].setAlpha(1.0f);
                         } catch (Exception e) {
                             e.printStackTrace();
                         }
@@ -6914,6 +6935,7 @@ public class StageMode extends AppCompatActivity implements
     public void changePDFPage(int page, String direction) {
         FullscreenActivity.whichDirection = direction;
         FullscreenActivity.pdfPageCurrent = page;
+        StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
         loadSong();
     }
 
@@ -6925,22 +6947,36 @@ public class StageMode extends AppCompatActivity implements
                 // It will get set back to false in the post execute of the async task
                 FullscreenActivity.alreadyloading = true;
 
-                // Stop the metronome now as it is high drain and breaks async starts!
+                // IV - For a load
                 if (!StaticVariables.reloadOfSong) {
+                    // Stop the metronome now as it is high drain and breaks async starts!
                     Metronome.stopMetronomeTask();
-                }
-
-                // IV - For a reload, load the stored whichSongFolder in case we were browsing elsewhere
-                if (StaticVariables.reloadOfSong) {
+                    // IV - Set current section
+                    if (StaticVariables.currentSection >= 0) {
+                        StaticVariables.currentSection = 0;
+                    } else {
+                        // IV - Consume any pending client section change received from Host (-ve value)
+                        StaticVariables.currentSection = -(1 + StaticVariables.currentSection);
+                    }
+                    // IV - Clear sendSong Handlers and send a pending section change for the current section
+                    if (StaticVariables.isHost && StaticVariables.isConnected) {
+                        sendSongAfterDelayHandler.removeCallbacks(sendSongAfterDelayRunnable);
+                        resetSendSongAfterDelayHandler.removeCallbacks(resetSendSongAfterDelayRunnable);
+                        if (StaticVariables.whichMode.equals("Stage")) {
+                            sendSongSectionForPendingToConnected();
+                        }
+                    }
+                } else {
+                    // IV - For a reload, load the stored whichSongFolder in case we were browsing elsewhere
                     StaticVariables.whichSongFolder = preferences.getMyPreferenceString(StageMode.this,"whichSongFolder", getString(R.string.mainfoldername));
                 }
+
+                FullscreenActivity.pdfPageCurrent = StaticVariables.currentSection;
 
                 // Clear any queued 'after song display' activity - we are moving to a new song
                 startCapoAnimationHandler.removeCallbacks(startCapoAnimationRunnable);
                 startAutoscrollHandler.removeCallbacks(startAutoscrollRunnable);
                 showStickyHandler.removeCallbacks(showStickyRunnable);
-                sendSongAfterDelayHandler.removeCallbacks(sendSongAfterDelayRunnable);
-                resetSendSongAfterDelayHandler.removeCallbacks(resetSendSongAfterDelayRunnable);
 
                 // If there is a sticky note showing, remove it early
                 if (stickyPopUpWindow != null && stickyPopUpWindow.isShowing()) {
@@ -8112,9 +8148,9 @@ public class StageMode extends AppCompatActivity implements
 
     // Redraw the lyrics page
     private void gesture4() {
-        // IV - Reset PDF page just in case song is a PDF
         StaticVariables.reloadOfSong = true;
         FullscreenActivity.pdfPageCurrent = 0;
+        StaticVariables.currentSection = 0;
         loadSong();
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -6936,6 +6936,7 @@ public class StageMode extends AppCompatActivity implements
         FullscreenActivity.whichDirection = direction;
         FullscreenActivity.pdfPageCurrent = page;
         StaticVariables.currentSection = FullscreenActivity.pdfPageCurrent;
+        StaticVariables.reloadOfSong = true;
         loadSong();
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -8152,6 +8152,10 @@ public class StageMode extends AppCompatActivity implements
         StaticVariables.reloadOfSong = true;
         FullscreenActivity.pdfPageCurrent = 0;
         StaticVariables.currentSection = 0;
+        // Send section to other devices
+        if (StaticVariables.isHost && StaticVariables.isConnected) {
+            sendSongSectionToConnected();
+        }
         loadSong();
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,60 +609,73 @@
     <string name="user_guide">User guide</string>
     <string name="user_guide_lyrics" translatable="false">"[Intro]
  Welcome to OpenSongApp!
- This is a test page to show you some of the features of the app.
- The app contains 3 modes -
-• Performance Mode - use your Android device as a song book on stage
-• Stage Mode - control stage display monitors or hook up to a projector
-• Presentation Mode - hook up to a projector and displaying lyrics\n
+ This is an information page to show you some of the features of the app.
+ OpenSongApp has many more features across three modes:
+     • Performance Mode - use your Android device as a song book on stage
+     • Stage Mode - control stage display monitors or hook up to a projector
+     • Presentation Mode - hook up to a projector and display lyrics
+
 [Menus]
- The left hand slide out menu - lists all folders and songs.
- The right hand slide out menu - all options/settings.
- The taskbar menu - access different modes, menus or features.
- The page icons let you access special song features:
-;Backing track, auto scroll, metronome, chords, notes, links, etc.\n
+ The left hand slide out song menu - lists all folders and songs.
+ The right hand slide out options menu - all options/settings.
+ The taskbar menu - access different modes, menus or features.
+ The page buttons let you access special song features:
+ backing track, auto scroll, metronome, chords, notes, links, and more!
+
 [Get help with all of the cool features…]
  To find out all of the app features and how to use them,
  please check out the online help pages.
- Use the link in the options menu under the \'Other\' category -
- http://www.opensongapp.com
- You can also click on the link icon page button.\n
+ Use \'Help (Online)\' in the options menu under the \'Other\' category to
+ visit http://www.opensongapp.com
+
 [Adding songs]
- You can manually enter/create any song you like
+ You can manually enter/create any song you like.
  The app only comes with this \'song\' by default due to copyright.
- You can also import songs from other services:
-• Desktop OpenSong - I highly recommend syncing using Dropbox
-• ChordPro files
-• Ultimate Guitar website (using the import feature)
-• Chordie website (using the import feature)
-• SongSelect .usr files
-• some iOS app song files
- Songs are stored in OpenSong format (XML files without the .xml etension)\n
- Songs are stored on your device in the /OpenSong/Songs folder.
- This location is found at the storage location you chose
- when you first ran the app.  Check out the \'Storage\' category
- of the options menu to see where this is.\n
+ You can start a song by import from other services:
+     • Desktop OpenSong - I highly recommend syncing using Dropbox
+     • ChordPro files
+     • Ultimate Guitar website (using the import feature)
+     • Chordie website (using the import feature)
+     • SongSelect .usr files
+     • some iOS app song files
+ and then edit it to get your OpenSong version.
+ Use \'Find new songs\' in the options menu.
+
+ Songs are stored on your device in OpenSong format
+ (XML files without the .xml etension) in the /OpenSong/Songs folder.
+ This folder is the storage location you chose when you first ran the app.
+ Check out the \'Storage\' category of the options menu to see where this is.
+
 [Edit the song]
  Click on the song title in the menu bar to see a song preview.
- This also allows you to quickly edit the song\n
+ This also allows you to quickly edit the song.
+
 [Chords at work]
  This song has been set as having a key of G.
- You can also set capo display options easily
 .G     D      Em           C      G         G7
  Chord lines (above) start with a full stop/period (.)
-.C       Em            D      G
- You can transpose the chords easily.
- This is done from the chords category in the options menu
- Nashville, European and Do Ré Mi chords are understood\n
+ You can set capo display and transpose the chords easily,
+ this is done from the \'Chords\' category in the options menu.
+ Nashville, European and Do Ré Mi chords are understood.
+
 [Scaling]
  By default OpenSongApp scales a song to fit the page.
- You can change the auto scale options in the right hand menu\n
+ You can change the \'Display\' \'Autoscale\' options
+ in the options menu.
+
 [Sets]
- Add songs to sets by long pressing on them in the song menu\n
+ Add songs to sets by long pressing on them in the song menu.
+
 [Customising]
  You can customise colours, themes, fonts, gestures, pedal actions, etc.
  These customisations can be saved as user profiles.
- Check out the categories in the right hand options menu.\n\n
- HERE IS AN EXAMPLE OF HOW A SONG WOULD LOOK\n\n
+ Check out the categories in the right hand options menu.
+;
+ HERE IS AN EXAMPLE OF A SONG
+ Edit this song and look at /'Lyrics/' to see how it was done!
+
+[Intro]
+.||: G  | D/F#  | Em7  | D  :||
 [V1]
 .G2                D/F#
  Love everlasting, love without measure,
@@ -692,7 +705,10 @@
 .Em7                      D
  Loving each other, since Christ first loved us;
 .C          G/B             Am7        C/D      D
-Sharing my Saviour\'s love, showing my Father\'s heart."</string>
+Sharing my Saviour\'s love, showing my Father\'s heart.
+[Outro]
+;(Slow to end)
+.| G  |"</string>
     <string name="user_guide_text">Please take the time to read the user guide before using the app.</string>
     <string name="variation">Variation</string>
     <string name="variation_edit">This item can be edited.  The original will be unaffected.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,7 +672,7 @@
  Check out the categories in the right hand options menu.
 ;
  HERE IS AN EXAMPLE OF A SONG
- Edit this song and look at /'Lyrics/' to see how it was done!
+ Edit this song and look at \'Lyrics\' to see how it was done!
 
 [Intro]
 .||: G  | D/F#  | Em7  | D  :||


### PR DESCRIPTION
Hello Gareth,

A host sending section changes and a client using section changes are kept in better step - important for 'Stage' controlling 'Presentation'.

I did not want to throw out first and last song (with delay) being sent to clients during rapid song changes  This handles section changes in the delay period - previously changing the clients old song and not being applied to the new song!  Sorted.

I think I need a rest!

Kind regards
Ian

