### PR TITLE
Alpha index xml revert and move of padding into code

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongDetailsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongDetailsFragment.java
@@ -119,9 +119,9 @@ public class PopUpSongDetailsFragment extends DialogFragment {
                 songInformation.append("").append(mcapo);
             }
 
-            Transpose transpose = new Transpose();
-            if (!StaticVariables.mKey.equals("")) {
-                songInformation.append(" (").append(transpose.capoTranspose(getContext(), preferences, StaticVariables.mKey)).append(")");
+            if (!StaticVariables.mCapo.equals("") && !StaticVariables.mKey.equals("") &&
+                    !FullscreenActivity.capokey.equals("")) {
+                songInformation.append(" (").append(FullscreenActivity.capokey).append(")");
             }
         }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
@@ -45,9 +45,10 @@ public class PopUpTransposeFragment extends DialogFragment {
     }
 
     private SeekBar transposeSeekBar;
-    private TextView transposeValTextView, keyChange_TextView, detectedChordFormatText;
+    private TextView transposeValTextView, keyChange_TextView, capoChange_TextView, detectedChordFormatText;
     private RadioButton chordFormat1Radio, chordFormat2Radio, chordFormat3Radio, chordFormat4Radio,
             chordFormat5Radio, chordFormat6Radio;
+    private SwitchCompat tranposeCapo_SwitchCompat;
     private SwitchCompat assumePreferred_SwitchCompat;
     private Preferences preferences;
     private Transpose transpose;
@@ -114,12 +115,14 @@ public class PopUpTransposeFragment extends DialogFragment {
         transposeSeekBar = V.findViewById(R.id.transposeSeekBar);
         transposeValTextView = V.findViewById(R.id.transposeValTextView);
         keyChange_TextView = V.findViewById(R.id.keyChange_TextView);
+        capoChange_TextView = V.findViewById(R.id.capoChange_TextView);
         chordFormat1Radio = V.findViewById(R.id.chordFormat1Radio);
         chordFormat2Radio = V.findViewById(R.id.chordFormat2Radio);
         chordFormat3Radio = V.findViewById(R.id.chordFormat3Radio);
         chordFormat4Radio = V.findViewById(R.id.chordFormat4Radio);
         chordFormat5Radio = V.findViewById(R.id.chordFormat5Radio);
         chordFormat6Radio = V.findViewById(R.id.chordFormat6Radio);
+        tranposeCapo_SwitchCompat = V.findViewById(R.id.transposeCapo_SwitchCompat);
         assumePreferred_SwitchCompat = V.findViewById(R.id.assumePreferred_SwitchCompat);
         detectedChordFormatText = V.findViewById(R.id.detectedChordFormatText);
     }
@@ -163,6 +166,10 @@ public class PopUpTransposeFragment extends DialogFragment {
                 chordFormat6Radio.setChecked(true);
                 break;
         }
+
+        tranposeCapo_SwitchCompat.setText(getString(R.string.transpose) + " " + getString(R.string.edit_song_capo));
+        capoChange_TextView.setText(getString(R.string.transpose) + " " + getString(R.string.edit_song_capo));
+        tranposeCapo_SwitchCompat.setChecked(true);
     }
 
     private void setListeners() {
@@ -213,6 +220,13 @@ public class PopUpTransposeFragment extends DialogFragment {
         assumePreferred_SwitchCompat.setOnCheckedChangeListener((buttonView, isChecked) -> {
             // IV -  Set of preference removed - we now use preference only as an aid to selecting
             usePreferredChordFormat(isChecked);
+        });
+        tranposeCapo_SwitchCompat.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                capoChange_TextView.setText(getString(R.string.transpose) + " " + getString(R.string.edit_song_capo));
+            } else {
+                capoChange_TextView.setText("");
+            }
         });
     }
 
@@ -305,6 +319,14 @@ public class PopUpTransposeFragment extends DialogFragment {
 
         // Do the transpose
         try {
+            // If requested transpose the capo fret number
+            if (tranposeCapo_SwitchCompat.isChecked()) {
+                StaticVariables.mCapo = String.valueOf(((Integer.parseInt("0" + StaticVariables.mCapo) + 12 + (StaticVariables.transposeTimes * Integer.parseInt(StaticVariables.transposeDirection))) % 12));
+                if (StaticVariables.mCapo.equals("0")) {
+                    StaticVariables.mCapo = "";
+                }
+            }
+            // doTranspose will write the song including any transposed capo
             transpose.doTranspose(getContext(), preferences, false, false);
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
@@ -169,7 +169,7 @@ public class PopUpTransposeFragment extends DialogFragment {
 
         tranposeCapo_SwitchCompat.setText(getString(R.string.transpose) + " " + getString(R.string.edit_song_capo));
         capoChange_TextView.setText(getString(R.string.transpose) + " " + getString(R.string.edit_song_capo));
-        tranposeCapo_SwitchCompat.setChecked(true);
+        tranposeCapo_SwitchCompat.setChecked(false);
     }
 
     private void setListeners() {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -2762,7 +2762,9 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                 textView = (TextView) View.inflate(PresenterMode.this,R.layout.leftmenu, null);
                 textView.setTextSize(preferences.getMyPreferenceFloat(PresenterMode.this,"songMenuAlphaIndexSize", 4.0f));
                 int i = (int) preferences.getMyPreferenceFloat(PresenterMode.this,"songMenuAlphaIndexSize",14.0f) *2;
-                textView.setPadding(i,i,i,i);
+                textView.setPadding(i+4,i,i-12,i);
+                textView.setMinimumWidth(48);
+                textView.setMinimumHeight(48);
                 textView.setText(index);
                 textView.setOnClickListener(view -> {
                     TextView selectedIndex = (TextView) view;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -3031,7 +3031,7 @@ public class ProcessSong extends Activity {
             // IV - Try to generate a capo/key/tempo/time line
             String sprefix = ";";
 
-            if (displayCapoChords) {
+            if (preferences.getMyPreferenceBoolean(c, "displayCapoChords", true)) {
                 if (!StaticVariables.mCapo.equals("") && !StaticVariables.mCapo.equals("0")) {
                     // If we are using a capo, add the capo display
                     songInformation.append(sprefix).append("Capo: ");
@@ -3048,9 +3048,10 @@ public class ProcessSong extends Activity {
                         songInformation.append("").append(mcapo);
                     }
 
-                    Transpose transpose = new Transpose();
                     if (!StaticVariables.mKey.equals("")) {
-                        songInformation.append(" (").append(transpose.capoTranspose(c, preferences, StaticVariables.mKey)).append(")");
+                        Transpose transpose = new Transpose();
+                        transpose.capoKeyTranspose(c, preferences);
+                        songInformation.append(" (").append(FullscreenActivity.capokey).append(")");
                     }
                 }
             }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -5265,8 +5265,8 @@ public class StageMode extends AppCompatActivity implements
             for (String index : indexList) {
                 textView = (TextView) View.inflate(StageMode.this,R.layout.leftmenu, null);
                 textView.setTextSize(preferences.getMyPreferenceFloat(StageMode.this,"songMenuAlphaIndexSize",14.0f));
-                int i = (int) ((int) preferences.getMyPreferenceFloat(StageMode.this,"songMenuAlphaIndexSize",14.0f) * 2.0f);
-                textView.setPadding(i,i,i,i);
+                int i = (int) ((int) preferences.getMyPreferenceFloat(StageMode.this,"songMenuAlphaIndexSize",14.0f) * 2f);
+                textView.setPadding(i+4,i,i-12,i);
                 textView.setMinimumWidth(48);
                 textView.setMinimumHeight(48);
                 textView.setText(index);

--- a/app/src/main/res/layout/popup_transpose.xml
+++ b/app/src/main/res/layout/popup_transpose.xml
@@ -43,15 +43,26 @@
                 android:textIsSelectable="true"
                 android:textSize="32sp" />
 
-
             <TextView
                 android:id="@+id/keyChange_TextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginTop="8dp"
                 android:gravity="center_horizontal"
                 android:text="@string/edit_song_key"
                 android:textSize="28sp" />
+
+            <TextView
+                android:id="@+id/capoChange_TextView"
+                style="@style/MyInfoText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                android:gravity="center_horizontal" />
 
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/assumePreferred_SwitchCompat"
@@ -69,61 +80,74 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/detectedChordFormatText"
-                style="@style/MyHeadingText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="8dp"
-                android:text="@string/oldchordformat" />
+                <TextView
+                    android:id="@+id/detectedChordFormatText"
+                    style="@style/MyHeadingText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:text="@string/oldchordformat" />
 
-            <RadioGroup
-                android:id="@+id/detectedChordFormat"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <RadioButton
-                    android:id="@+id/chordFormat1Radio"
-                    style="@style/MyInfoText"
+                <RadioGroup
+                    android:id="@+id/detectedChordFormat"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/chordFormat1" />
+                    android:layout_marginStart="8dp">
 
-                <RadioButton
-                    android:id="@+id/chordFormat2Radio"
-                    style="@style/MyInfoText"
+                    <RadioButton
+                        android:id="@+id/chordFormat1Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat1" />
+
+                    <RadioButton
+                        android:id="@+id/chordFormat2Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat2" />
+
+                    <RadioButton
+                        android:id="@+id/chordFormat3Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat3" />
+
+                    <RadioButton
+                        android:id="@+id/chordFormat4Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat4" />
+
+                    <RadioButton
+                        android:id="@+id/chordFormat5Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat5" />
+
+                    <RadioButton
+                        android:id="@+id/chordFormat6Radio"
+                        style="@style/MyInfoText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/chordFormat6" />
+                </RadioGroup>
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/transposeCapo_SwitchCompat"
+                    style="@style/MyHeadingText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/chordFormat2" />
+                    android:layout_gravity="center_vertical"
+                    android:layout_margin="8dp"
+                    android:minHeight="48dp"
+                    android:text="@string/edit_song_capo"
+                    android:theme="@style/SwitchStyle" />
 
-                <RadioButton
-                    android:id="@+id/chordFormat3Radio"
-                    style="@style/MyInfoText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/chordFormat3" />
-
-                <RadioButton
-                    android:id="@+id/chordFormat4Radio"
-                    style="@style/MyInfoText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/chordFormat4" />
-
-                <RadioButton
-                    android:id="@+id/chordFormat5Radio"
-                    style="@style/MyInfoText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/chordFormat5" />
-
-                <RadioButton
-                    android:id="@+id/chordFormat6Radio"
-                    style="@style/MyInfoText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/chordFormat6" />
-            </RadioGroup>
             </LinearLayout>
 
         </LinearLayout>

--- a/app/src/main/res/layout/songmenu.xml
+++ b/app/src/main/res/layout/songmenu.xml
@@ -95,11 +95,9 @@
                 android:id="@+id/side_index"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingEnd="-8dp"
-                android:paddingStart="4dp"
-                android:minWidth="1dp"
-                android:gravity="center_horizontal|center_vertical"
-                android:orientation="vertical"/>
+                android:padding="1dp"
+                android:gravity="center_horizontal"
+                android:orientation="vertical" />
         </ScrollView>
 
         <ListView


### PR DESCRIPTION
Hello Gareth,

I noticed the report of Alpha Index looking odd... as I am familiar with this code I have taken a look.  This commit includes a less 'odd' solution to controlling the width of the index.  I could not re-create the small text seen in the report!  This removes the use of negative margins in xml (might be unstable) and (in code) adds minimum sizing etc.  It is difficult to know it will fix the issue but it seems a safer approach.

Plus other bits carried along with it!

Kind regards
Ian 