### PR TITLE
Fixes Revised Solfege Transpose

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -7,6 +7,8 @@ import android.util.Log;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 class ChordProConvert {
 
@@ -42,7 +44,7 @@ class ChordProConvert {
         lyrics = makeTagsCommon(lyrics);
 
         // Fix content we recognise
-        lyrics = fixRecognisedContent(lyrics);
+        lyrics = fixRecognisedContent(c, lyrics);
 
         // Now that we have the basics in place, we will go back through the song and extract headings
         // We have to do this separately as [] were previously identifying chords, not tags.
@@ -229,7 +231,7 @@ class ChordProConvert {
         return s;
     }
 
-    private String fixRecognisedContent(String l) {
+    private String fixRecognisedContent(Context c, String l) {
         // Break the filecontents into lines
         lines = l.split("\n");
 
@@ -282,6 +284,21 @@ class ChordProConvert {
             } else if (line.contains("{key:")) {
                 // Extract the key
                 key = removeTags(line, "{key:");
+                // Key may be from import of a Solfege SongSelect song, transpose any Solfege key just in case
+                final String[] fromSongSelectSolfege =  "LA SI DO RE MI FA SOL".split(" ");
+                final String[] toStandard =  "A B C D E F G".split(" ");
+                for (int z = 0; z < fromSongSelectSolfege.length; z++) key = key.replace(fromSongSelectSolfege[z], toStandard[z]);
+                // Check the key is a Standard key - if not set no key
+                int index = -1;
+                List<String> key_choice = Arrays.asList(c.getResources().getStringArray(R.array.key_choice));
+                for (int w = 0; w < key_choice.size();w++) {
+                    if (key.equals(key_choice.get(w))) {
+                        index = w;
+                    }
+                }
+                if (index == -1) {
+                    key = "";
+                }
                 line = "";
 
             } else if (line.contains("{tempo:")) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProfileActions.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProfileActions.java
@@ -315,10 +315,10 @@ class ProfileActions {
                             preferences.setMyPreferenceString(c,"chordInstrument",getTextValue(xppValue,"g"));
                             break;
 
-                        case "chosenstorage":        // New preference only
+                        /*case "chosenstorage":        // New preference only
                             //chosenstorage                   String      The uri of the document tree (Storage Access Framework)
                             preferences.setMyPreferenceString(c,"chosenstorage",getTextValue(xppValue,null));
-                            break;
+                            break;*/
 
                         case "clock24hFormat":        // New preference only
                         case "timeFormat24h":
@@ -1034,10 +1034,10 @@ class ProfileActions {
                             preferences.setMyPreferenceString(c,"language",getTextValue(xppValue,"en"));
                             break;
 
-                        case "lastUsedVersion":        // New preference
+                        /*case "lastUsedVersion":        // New preference
                             //lastUsedVersion                 int         The app version number the last time the app ran
                             preferences.setMyPreferenceInt(c,"lastUsedVersion",getIntegerValue(xppValue,0));
-                            break;
+                            break;*/
 
                         case "light_lyricsBackgroundColor":        // New preference only
                             //light_lyricsBackgroundColor   int         The color for the lyrics background in the custom1 theme
@@ -1772,10 +1772,10 @@ class ProfileActions {
                             preferences.setMyPreferenceString(c,"randomSongFolderChoice",getTextValue(xppValue,""));
                             break;
 
-                        case "runswithoutbackup":        // New preference
+                        /*case "runswithoutbackup":        // New preference
                             //runswithoutbackup               int         The number of times the app has opened without backup (prompt the user after 10)
                             preferences.setMyPreferenceInt(c,"runswithoutbackup",getIntegerValue(xppValue,0));
-                            break;
+                            break;*/
 
                         case "scaleChords":        // New preference
                         case "chordfontscalesize":        // Old preference
@@ -1875,7 +1875,7 @@ class ProfileActions {
                             preferences.setMyPreferenceBoolean(c,"searchUser3",getBooleanValue(xppValue,true));
                             break;
 
-                        case "setCurrent":        // New preference
+                        /*case "setCurrent":        // New preference
                         case "mySet":        // Old preference
                             //setCurrent                      String      The current set (each item enclosed in $**_folder/song_**$) - gets parsed on loading app
                             preferences.setMyPreferenceString(c,"setCurrent",getTextValue(xppValue,""));
@@ -1890,7 +1890,7 @@ class ProfileActions {
                         case "lastSetName":        // Old preference
                             //setCurrentLastName              String      The last name used when saving or loading a set
                             preferences.setMyPreferenceString(c,"setCurrentLastName",getTextValue(xppValue,""));
-                            break;
+                            break;*/
 
                         case "songAuthorSize":        // New preference
                         case "ab_authorSize":
@@ -1920,16 +1920,15 @@ class ProfileActions {
                             preferences.setMyPreferenceBoolean(c,"songAutoScaleOverrideWidth",getBooleanValue(xppValue,false));
                             break;
 
-                            // Don't include the songfilename
-                       /* case "songfilename":        // New preference
+                        /*case "songfilename":        // New preference
                             //songfilename                    String      The name of the current song file
                             preferences.setMyPreferenceString(c,"songfilename",getTextValue(xppValue,""));
-                            break;*/
+                            break;
 
                         case "songLoadSuccess":        // New preference
                             //songLoadSuccess                 boolean     Indicates if the song loaded correctly (won't load a song next time if it crashed)
                             preferences.setMyPreferenceBoolean(c,"songLoadSuccess",getBooleanValue(xppValue,false));
-                            break;
+                            break;*/
 
                         case "songMenuAlphaIndexShow":        // New preference
                         case "showAlphabeticalIndexInSongMenu":        // Old preference
@@ -2060,7 +2059,6 @@ class ProfileActions {
                             preferences.setMyPreferenceBoolean(c,"trimLines",getBooleanValue(xppValue,true));
                             break;
 
-                            // Don't include the old storage!!!!!
                         /*case "uriTree":        // New preference
                             //uriTree                         String      A string representation of the user root location (may be the OpenSong folder or its parent)
                             preferences.setMyPreferenceString(c,"uriTree",getTextValue(xppValue,""));
@@ -2086,7 +2084,6 @@ class ProfileActions {
                             preferences.setMyPreferenceString(c,"whichMode",getTextValue(xppValue,"Performance"));
                             break;
 
-                            // Don't include the song folder
                         /*case "whichSongFolder":        // New preference
                             //whichSongFolder                 String      The song folder we are currently in
                             preferences.setMyPreferenceString(c,"whichSongFolder",getTextValue(xppValue,c.getString(R.string.mainfoldername)));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
@@ -24,6 +24,11 @@ class Transpose {
     //   from number ├W┤ is replaced to 3 Solfege «Solb   - ???    «««Solbm    ???
     //   '«««' is processed to remove 3 following spaces  - ???    Solbm ???
     //   In effect Solbm overwrites Fm and 3 spaces
+    //
+    // Replaces occur in order, with this used to perform logic.
+    // Example protect logic: Replace "maj7" to "¬aj7" to stop the m being treated as a minor, is followed by replace "¬" with "m" to restore it.
+    // Example variation handling logic: replace 'TI' with "SI, "Ti" with "SI" and "ti" with "SI" is followed by replace of "SI' with chord number "«├3┤"
+    // Three variants "TI", "Ti" and "ti" are therefore handled the same as SI.
 
     // Chord to number: 'majors' and sus interfere so are protected
     private final String [] fromchords1 =   {"maj7", "ma7", "maj9", "ma9",
@@ -62,17 +67,32 @@ class Transpose {
                                                    "├2┤",      "├4┤",      "├5┤",      "├7┤",      "├9┤",      "├W┤",      "├Y┤",
                                                   "«├Y┤",    "««├2┤",      "├3┤",      "├5┤",     "«├7┤",      "├8┤",      "├W┤",
                                                  "««├1┤",    "««├3┤",    "««├4┤",    "««├6┤",    "««├8┤",    "««├9┤",    "««├X┤",   "sus", "m"};
-    // Also handles variations of chord name
+    // Solfege variants
     private final String[] fromchords4 =    {"maj7", "ma7", "maj9", "ma9",
-                                             "la", "Ti", "ti", "si", "do", "Re", "re", "ré", "mi", "fa", "sol",
-                                             "LA", "TI", "DO", "RE", "RÉ", "MI", "FA", "SOL",
-                                                         "La#",    "Si#",    "Do#",    "Ré#",    "Mi#",    "Fa#",    "Sol#",
-                                                         "Lab",    "Sib",    "Dob",    "Réb",    "Mib",    "Fab",    "Solb",
-                                                         "La",     "Si",     "Do",     "Ré",     "Mi",     "Fa",     "Sol",   "¬"};
-    // GE Changed Ré to Re - some languages have the accents, some don't
+            // Variation handling: Transpose á é ó and case variants to 'uppercase, no accent' chords
+                                            "La", "la", "LÁ", "Lá", "lá",
+                                            "TI", "Ti", "ti",
+                                            "Si", "si",
+                                            "UT", "Ut", "ut",
+                                            "Do", "do", "DÓ", "Dó", "dó",
+                                            "Re", "re", "RÉ", "Ré", "ré",
+                                            "Mi", "mi",
+                                            "Fa", "fa", "FÁ", "Fá", "fá",
+                                            "Sol", "sol",
+            // Now, transpose 'uppercase, no accent' chords.
+                                                        "LA#",    "SI#",    "DO#",    "RE#",    "MI#",    "FA#",    "SOL#",
+                                                        "LAb",    "SIb",    "DOb",    "REb",    "MIb",    "FAb",    "SOLb",
+                                                        "LA",     "SI",     "DO",     "RE",     "MI",     "FA",     "SOL",   "¬"};
     private final String[] tochordsnums4 =  {"¬aj7", "¬a7", "¬aj9", "¬a9",
-                                             "La", "Si", "Si", "Si", "Do", "Re", "Re", "Re", "Mi", "Fa", "Sol",
-                                             "La", "Si", "Do", "Re", "Re", "Mi", "Fa", "Sol",
+                                            "LA", "LA", "LA", "LA", "LA",
+                                            "SI", "SI", "SI",
+                                            "SI", "SI",
+                                            "DO", "DO", "DO",
+                                            "DO", "DO", "DO", "DO", "DO",
+                                            "RE", "RE", "RE", "RE", "RE",
+                                            "MI", "MI",
+                                            "FA", "FA", "FA", "FA", "FA",
+                                            "SOL", "SOL",
                                                         "├2┤",    "├4┤",    "├5┤",    "├7┤",    "├9┤",    "├W┤",   "»├Y┤",
                                                         "├Y┤",    "├2┤",    "├3┤",    "├5┤",    "├7┤",    "├8┤",   "»├W┤",
                                                        "«├1┤",   "«├3┤",   "«├4┤",   "«├6┤",   "«├8┤",   "«├9┤",    "├X┤",    "m"};
@@ -85,9 +105,9 @@ class Transpose {
     private final String[] toflatchords1 =  "»Bb »Db »Eb »Gb »Ab »»A »»B »»C »»D »»E »»F »»G".split(" ");
     private final String[] tosharpchords2 = "»»B »C# »D# »F# »G# »»A »»H »»C »»D »»E »»F »»G".split(" ");
     private final String[] toflatchords2 =  "»»B »Db »Eb »Gb »Ab »»A »»H »»C »»D »»E »»F »»G".split(" ");
-    // GE Changed Ré to Re - some languages have the accents, some don't
-    private final String[] tosharpchords4 = "La# Do# Re# Fa# «Sol# »La »Si »Do »Re »Mi »Fa Sol".split(" ");
-    private final String[] toflatchords4 =  "Sib Reb Mib «Solb Lab »La »Si »Do »Re »Mi »Fa Sol".split(" ");
+    // IV - Solfege out format is 'SongSelect fixed DO' - Capitals = easy to read, no accents = easy to type, DO not UT and SI not TI = most common across solfege variants
+    private final String[] tosharpchords4 = "LA# DO# RE# FA# «SOL# »LA »SI »DO »RE »MI »FA SOL".split(" ");
+    private final String[] toflatchords4 =  "SIb REb MIb «SOLb LAb »LA »SI »DO »RE »MI »FA SOL".split(" ");
     //  A trick! Minors arrive ending ┤m, the m is moved into the number to give numbers for minors. '┤ma' is treated as the start of major and is protected.
     private final String[] fromchordsnumm = "┤ma ┤m ├2m┤ ├5m┤ ├7m┤ ├Wm┤ ├Ym┤ ├1m┤ ├3m┤ ├4m┤ ├6m┤ ├8m┤ ├9m┤ ├Xm┤ ├2┤ ├5┤ ├7┤ ├W┤ ├Y┤ ├1┤ ├3┤ ├4┤ ├6┤ ├8┤ ├9┤ ├X┤ ¬".split(" ");
     private final String[] tosharpchords3 = "┤¬a m┤ »»»b »cis »dis »fis »gis »»»a »»»h »»»c »»»d »»»e »»»f »»»g »»B Cis Dis Fis Gis »»A »»H »»C »»D »»E »»F »»G m".split(" ");
@@ -106,8 +126,8 @@ class Transpose {
     private int root;
 
     private static final String[] format2Identifiers = new String[]{"h"};
-    private static final String[] format3Identifiers = new String[]{"a", "c", "d", "e,", "f", "g"}; // Format 3 has lowecase minors. 'b' is 'flat', "h" is dealt with separatly so both not tested
-    private static final String[] format4Identifiers = new String[]{"do","re","ré","mi","fa","sol","la","si"};
+    private static final String[] format3Identifiers = new String[]{"a","c","d","e,","f","g"}; // Format 3 has lowecase minors. 'b' is 'flat', "h" is dealt with separatly so both not tested
+    private static final String[] format4Identifiers = new String[]{"do","dó","re","ré","mi","fa","fá","sol","la","lá", "si","ti"};
     private static final String[] format5Identifiers = new String[]{"1","2","3","4","5","6","7"};
     private static final String[] format6Identifiers = new String[]{"i","ii","ii","iii","iii","iv","iv","v","vi","vii"};
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="chordFormat1" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/Bb  B</string>
     <string name="chordFormat2" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  B   H</string>
     <string name="chordFormat3" translatable="false">C  Cis/Des  D  Dis/Es  E  F  Fis/Ges  G  Gis/As  A  B  H</string>
-    <string name="chordFormat4" translatable="false">Do  Do#/Reb  Re  Re#/Mib  Mi  Fa  Fa#/Solb  Sol  Sol#/Lab  La  La#/Sib Si</string>
+    <string name="chordFormat4" translatable="false">DO  DO#/REb  RE  RE#/MIb  MI  FA  FA#/SOLb  SOL  SOL#/LAb  LA  LA#/SIb SI</string>
     <string name="chordFormat5" translatable="false">1  2  3  4  5  6  7  8  9  10  11  12</string>
     <string name="chordFormat6" translatable="false">I  II  III  IV  V  VI  VII  VIII  IX  X  XI  XII</string>
     <string name="chord_color">Chords font</string>


### PR DESCRIPTION
Hello Gareth,

Here is SongSelect Fixed DO!

I saw the conversation about spacing changes on transpose. We are already code to prevent transpose running chords together - there is always a space between chords.

For your example
```
.G C  D  G
 A short line
```
Transposing this by +3 (to Bb) would give
```
.Bb Eb F Bb
 A short line
```
Chords have wandered - the Eb is over 'h' and F is now over 't'.

For SongSelect (which spaces chords well) the line would start as

```
.G  C     D  G
 A  sho - rt line
```
And transpose to

```
.Bb Eb    F  Bb
 A  sho - rt line
```
All chords are in their correct position.  Reverse transpose would generate the original line.

SongSelect uses a minimum of 2 spaces between chords and ' - ' wherever a chord splits a word.  This means Capo display keeps very good chord positions and transpose works well with minimal need to correct chord positions / adjust to SongSelect spacing using edit.

A well thought out song layout style (thanks SongSelect) avoids much pain  Happily I source songs from SongSelect!

Anyway... enjoy SongSelect Fixed DO!

Kind regards
Ian