### PR TITLE
HOTFIX: Song Menu ticks missing after set edit

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExternalFile.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExternalFile.java
@@ -613,8 +613,14 @@ public class PopUpImportExternalFile extends DialogFragment {
                     setActions.loadASet(getContext(), preferences, storageAccess);
                     StaticVariables.setView = true;
 
-                    // Get the set first item
-                    setActions.prepareFirstItem(getContext(),preferences);
+                    // Prepare the set
+                    setActions.prepareSetList(getContext(), preferences);
+                    setActions.indexSongInSet();
+
+                    // IV - For presentation mode - Get the set first item
+                    if (StaticVariables.whichMode.equals("Presentation")) {
+                        setActions.prepareFirstItem(getContext(), preferences);
+                    }
 
                     StaticVariables.myToastMessage = getString(R.string.success);
 
@@ -636,7 +642,6 @@ public class PopUpImportExternalFile extends DialogFragment {
             try {
                 mListener.showToastMessage(StaticVariables.myToastMessage);
                 if (!error) {
-                    mListener.refreshAll();
                     FullscreenActivity.whattodo = "editset";
                     mListener.openFragment();
                 }
@@ -667,10 +672,14 @@ public class PopUpImportExternalFile extends DialogFragment {
                 setActions.loadASet(getContext(), preferences, storageAccess);
                 StaticVariables.setView = true;
 
+                // Prepare the set
                 setActions.prepareSetList(getContext(), preferences);
+                setActions.indexSongInSet();
 
-                // Get the set first item
-                setActions.prepareFirstItem(getContext(), preferences);
+                // IV - For presentation mode -  Get the set first item
+                if (StaticVariables.whichMode.equals("Presentation")) {
+                    setActions.prepareFirstItem(getContext(), preferences);
+                }
 
                 StaticVariables.myToastMessage = getString(R.string.success);
 
@@ -687,7 +696,6 @@ public class PopUpImportExternalFile extends DialogFragment {
             try {
                 mListener.showToastMessage(StaticVariables.myToastMessage);
                 if (!error) {
-                    mListener.refreshAll();
                     FullscreenActivity.whattodo = "editset";
                     mListener.openFragment();
                 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpListSetsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpListSetsFragment.java
@@ -751,8 +751,8 @@ public class PopUpListSetsFragment extends DialogFragment {
             // Add all the songs of combined sets back to the mySet
             preferences.setMyPreferenceString(getContext(), "setCurrent", allsongsinset.toString());
 
-            // Reset the options menu
-            //setActions.prepareSetList(getContext(), preferences);
+            // Prepare the set
+            setActions.prepareSetList(getContext(), preferences);
             setActions.indexSongInSet();
 
             return "LOADED";
@@ -769,11 +769,11 @@ public class PopUpListSetsFragment extends DialogFragment {
 
             if (result.equals("LOADED") && !dataTask.isCancelled()) {
                 try {
-                    // Get the set first item
-                    setActions.prepareFirstItem(getContext(),preferences);
+                    // IV - For presentation mode - Get the set first item
+                    if (StaticVariables.whichMode.equals("Presentation")) {
+                        setActions.prepareFirstItem(getContext(), preferences);
+                    }
 
-                    // Tell the listener to do something
-                    mListener.refreshAll();
                     FullscreenActivity.whattodo = "editset";
                     mListener.openFragment();
                     //Close this dialog

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
@@ -185,9 +185,11 @@ public class PopUpSetViewNew extends DialogFragment {
         }
         Log.d(TAG,"mTempSetList.size()="+StaticVariables.mTempSetList.size());
         for (int z = 0; z < StaticVariables.mTempSetList.size(); z++) {
-            // IV - Use displayed info as is in the desired order
-            tempItem = mFolderName.get(z) + "/" + mSongName.get(z);
-            tempmySet.append("$**_").append(tempItem).append("_**$");
+            // IV - Use displayed info as it is in the desired order, with required 'MAIN' (root) folder handling
+            tempItem = ("$**_" + mFolderName.get(z) + "/" + mSongName.get(z) + "_**$").
+                    replace("$**_MAIN/", "$**_").
+                    replace("$**_" + getString(R.string.mainfoldername) + "/", "$**_");
+            tempmySet.append(tempItem);
         }
         Log.d(TAG,"tempmySet: "+tempmySet);
         preferences.setMyPreferenceString(getContext(),"setCurrent",tempmySet.toString());

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
@@ -198,12 +198,6 @@ public class PopUpSetViewNew extends DialogFragment {
                 " - " + getString(R.string.ok);
     }
 
-    private void refresh() {
-        if (mListener != null) {
-            mListener.refreshAll();
-        }
-    }
-
     private void close() {
         try {
             dismiss();
@@ -464,6 +458,8 @@ public class PopUpSetViewNew extends DialogFragment {
 
         void refreshAll();
 
+        void onScrollAction();
+
         void closePopUps();
 
         void pageButtonAlpha(String s);
@@ -503,8 +499,12 @@ public class PopUpSetViewNew extends DialogFragment {
             mListener.pageButtonAlpha("");
             mListener.windowFlags();
             mListener.pageButtonAlpha(null);
+            // IV - For presentation mode refresh all
+            // IV - For performance modes only use onScrollAction to update the set buttons
             if (StaticVariables.whichMode.equals("Presentation")) {
-                refresh();
+                mListener.refreshAll();
+            } else {
+                mListener.onScrollAction();
             }
         }
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
@@ -276,7 +276,6 @@ public class PopUpSetViewNew extends DialogFragment {
         FloatingActionButton saveMe = V.findViewById(R.id.saveMe);
         saveMe.setOnClickListener(view -> {
             PopUpSetViewNew.this.doSave();
-            refresh();
             close();
         });
         if (FullscreenActivity.whattodo.equals("setitemvariation")) {
@@ -504,6 +503,9 @@ public class PopUpSetViewNew extends DialogFragment {
             mListener.pageButtonAlpha("");
             mListener.windowFlags();
             mListener.pageButtonAlpha(null);
+            if (StaticVariables.whichMode.equals("Presentation")) {
+                refresh();
+            }
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/SetActions.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/SetActions.java
@@ -346,71 +346,27 @@ class SetActions {
     }
 
     boolean isSongInSet(Context c, Preferences preferences) {
-        if (StaticVariables.setSize > 0) {
-            // Get the name of the song to look for (including folders if need be)
-            String songforsetwork;
-            String songforsetworkalt;
-            songforsetwork = getSongForSetWork(c);
-
-            songforsetwork = fixIsInSetSearch(songforsetwork);
-            songforsetworkalt = checkMain(c,songforsetwork);
-
-            String currset = preferences.getMyPreferenceString(c,"setCurrent","");
-
-            boolean containsitem = currset.contains(songforsetwork) || currset.contains(songforsetworkalt);
-
-            if (StaticVariables.setView && containsitem) {
-                // If we are currently in set mode, check if the new song is there, in which case do nothing else
-                indexSongInSet();
-                return true;
-
-            } else if (StaticVariables.setView && !currset.contains(songforsetwork) && !currset.contains(songforsetworkalt)) {
-                // If we are currently in set mode, but the new song isn't there, leave set mode
-                StaticVariables.setView = false;
-                StaticVariables.previousSongInSet = "";
-                StaticVariables.nextSongInSet = "";
-                StaticVariables.indexSongInSet = 0;
-                return false;
-
-            } else if (!StaticVariables.setView && containsitem) {
-                // If we aren't currently in set mode and the new song is there, enter set mode and get the index
+        // IV - Check if set contains the set entry for the song StaticVariables.whatsongforsetwork (which is only set on song load)
+        if (StaticVariables.setSize > 0 &&
+                preferences.getMyPreferenceString(c, "setCurrent", "").contains(StaticVariables.whatsongforsetwork)) {
+            // If we aren't currently in set mode, reset index
+            if (!StaticVariables.setView) {
+                StaticVariables.indexSongInSet = -1;
                 StaticVariables.setView = true;
-                StaticVariables.previousSongInSet = "";
-                StaticVariables.nextSongInSet = "";
-
-                // Get the song index
-                indexSongInSet();
-                return true;
-
-            } else if (!currset.contains(songforsetwork) && !currset.contains(songforsetworkalt)) {
-                // The new song isn't in the set, so leave set mode and reset index
-                StaticVariables.setView = false;
-                StaticVariables.previousSongInSet = "";
-                StaticVariables.nextSongInSet = "";
-                StaticVariables.indexSongInSet = 0;
-                return false;
             }
-
+            // Index the item which also sets previous and next variables
+            indexSongInSet();
+            return true;
         } else {
-            // User wasn't in set view, or the set was empty
-            // Switch off the set view (buttons in action bar)
-            StaticVariables.setView = false;
+            // Exit set mode
             StaticVariables.previousSongInSet = "";
             StaticVariables.nextSongInSet = "";
-            StaticVariables.indexSongInSet = 0;
-            return false;
+            StaticVariables.indexSongInSet = -1;
+            StaticVariables.setView = false;
         }
         return false;
     }
 
-    private String checkMain(Context c, String songforsetwork) {
-        if (songforsetwork.contains("MAIN/") || songforsetwork.contains(c.getString(R.string.mainfoldername)+"/") ||
-                songforsetwork.contains("/")) {
-            return songforsetwork;
-        } else {
-            return songforsetwork.replace("$**_","$**_"+c.getString(R.string.mainfoldername) + "/");
-        }
-    }
     void emptyCacheDirectories(Context c, Preferences preferences, StorageAccess storageAccess) {
         storageAccess.wipeFolder(c, preferences, "Scripture", "_cache");
         storageAccess.wipeFolder(c, preferences, "Slides", "_cache");

--- a/app/src/main/java/com/garethevans/church/opensongtablet/SongMenuAdapter.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/SongMenuAdapter.java
@@ -246,17 +246,27 @@ class SongMenuAdapter extends BaseAdapter implements SectionIndexer {
                     // IV - Consume the click - Do nothing
                     });
 
-                   viewHolder.lblListCheck.setOnClickListener(v -> {
+                    viewHolder.lblListCheck.setOnClickListener(v -> {
                         int position1 = (Integer) v.getTag();
-                        // Create the text to add to the set (sets FullscreenActivity.whatsongforsetwork
-                        String whatsongforsetwork;
+                        // Create the text to add to the set
+                        String whatsongforsetwork = "";
 
                         // Set the appropriate song filename
-                        if (whichSongFolder.equals(c.getString(R.string.mainfoldername)) || whichSongFolder.equals("MAIN") ||
-                                whichSongFolder.equals("")) {
+                        if (whichSongFolder.equals("") || whichSongFolder.equals(c.getString(R.string.mainfoldername)) || whichSongFolder.equals("MAIN")) {
                             whatsongforsetwork = "$**_" + item_filename + "_**$";
+                        // Handle a custom folder (should not happen but just in case!)
+                        } else if (whichSongFolder.startsWith("../")) {
+                            if (whichSongFolder.startsWith("../Variations")) {
+                               whatsongforsetwork = "$**_**" + c.getString(R.string.variation) + "/" + item_filename + "_**$";
+                            } else if (whichSongFolder.startsWith("../Notes")) {
+                               whatsongforsetwork = "$**_**" + c.getString(R.string.note) + "/" + item_filename + "_**$";
+                            } else if (whichSongFolder.startsWith("../Slides")) {
+                               whatsongforsetwork = "$**_**" + c.getString(R.string.slide) + "/" + item_filename + "_**$";
+                            } else if (whichSongFolder.startsWith("../Images")) {
+                                whatsongforsetwork = "$**_**" + c.getString(R.string.image_slide) + "/" + item_filename + "_**$";
+                            }
                         } else {
-                            whatsongforsetwork = "$**_" + whichSongFolder + "/" + item_filename + "_**$";
+                           whatsongforsetwork = "$**_" + whichSongFolder + "/" + item_filename + "_**$";
                         }
 
                         // If it was checked already, uncheck it and remove it from the set

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -1771,14 +1771,26 @@ public class StageMode extends AppCompatActivity implements
 
             // IV - Added handling for multi-page PDF
             // Use checkCanScroll results
-            // IV - Made invisible when so that they remain active areas on the screen
-            showFAB(scrollDownButton, checkCanScrollDown() || (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent < (FullscreenActivity.pdfPageCount - 1)));
-            showFAB(scrollUpButton, checkCanScrollUp() || (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0));
+            // IV - Made transparent so that they remain active areas on the screen
             if (!preferences.getMyPreferenceBoolean(StageMode.this, "pageButtonShowScroll", true)) {
-                scrollDownButton.setAlpha((0.0f));
-                scrollUpButton.setAlpha((0.0f));
+                scrollDownButton.setAlpha(0.0f);
+                scrollUpButton.setAlpha(0.0f);
+            } else {
+                // Get the default alpha value
+                float val = preferences.getMyPreferenceFloat(StageMode.this, "pageButtonAlpha", 0.5f);
+                scrollDownButton.setAlpha(val);
+                scrollUpButton.setAlpha(val);
             }
-
+            if (checkCanScrollDown() || (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent < (FullscreenActivity.pdfPageCount - 1))) {
+                scrollDownButton.setVisibility(View.VISIBLE);
+            } else {
+                scrollDownButton.setVisibility(View.GONE);
+            }
+            if (checkCanScrollUp() || (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0)) {
+                scrollUpButton.setVisibility(View.VISIBLE);
+            } else {
+                scrollUpButton.setVisibility(View.GONE);
+            };
 
             if (preferences.getMyPreferenceBoolean(StageMode.this, "pageButtonShowSetMove", true) && StaticVariables.setView ) {
                 // IV - Code removed - No longer support Set Move buttons making section moves in Stage mode here or in mext and previous item code
@@ -2589,8 +2601,6 @@ public class StageMode extends AppCompatActivity implements
             custom2Button_ungrouped.setAlpha(custom2Alpha);
             custom3Button_ungrouped.setAlpha(custom3Alpha);
             custom4Button_ungrouped.setAlpha(custom4Alpha);
-            scrollDownButton.setAlpha(val);
-            scrollUpButton.setAlpha(val);
             setBackButton.setAlpha(val);
             setForwardButton.setAlpha(val);
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -3483,16 +3483,14 @@ public class StageMode extends AppCompatActivity implements
                 // We weren't in set mode, so find the first instance of this song.
                 setActions.indexSongInSet();
             }
-            // If we aren't at the beginning or have pdf pages before this, indicate a setBackButton
-            StaticVariables.canGoToPrevious = (StaticVariables.indexSongInSet > 0) ||
-                    (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent > 0);
+            // If we aren't at the beginning indicate a set back button
+            StaticVariables.canGoToPrevious = StaticVariables.indexSongInSet > 0;
 
-            // If we aren't at the end of the set or inside a multipage pdf, indicate a setForwardButton
+            // If we aren't at the end of the set indicate a setForwardButton
             if (StaticVariables.mSetList==null) {
                 StaticVariables.mSetList = new String[0];
             }
-            StaticVariables.canGoToNext = (StaticVariables.indexSongInSet < StaticVariables.mSetList.length - 1) ||
-                        (FullscreenActivity.isPDF && FullscreenActivity.pdfPageCurrent < FullscreenActivity.pdfPageCount - 1);
+            StaticVariables.canGoToNext = StaticVariables.indexSongInSet < StaticVariables.mSetList.length - 1;
         } else {
             StaticVariables.canGoToPrevious = (FullscreenActivity.currentSongIndex > FullscreenActivity.previousSongIndex); // i.e there is a song before in the list/menu
             StaticVariables.canGoToNext = (FullscreenActivity.currentSongIndex < FullscreenActivity.nextSongIndex); // i.e there is a song after in the list/menu
@@ -7149,7 +7147,8 @@ public class StageMode extends AppCompatActivity implements
                     stopAutoScroll();
                 }
 
-                // Check for set song
+                // Check for set song (isSongInSet will index)
+                StaticVariables.whatsongforsetwork = setActions.getSongForSetWork(StageMode.this);
                 StaticVariables.setView = setActions.isSongInSet(StageMode.this, preferences);
 
                 // Sort the text size and colour of the info stuff
@@ -7266,10 +7265,6 @@ public class StageMode extends AppCompatActivity implements
                         resetSendSongAfterDelayHandler.postDelayed(resetSendSongAfterDelayRunnable, 3500);
                     }
                 }
-
-                // If we are in a set, try to get the appropriate indexes
-                StaticVariables.whatsongforsetwork = setActions.getSongForSetWork(StageMode.this);
-                setActions.indexSongInSet();
 
                 if (StaticVariables.mLyrics != null) {
                     FullscreenActivity.myLyrics = StaticVariables.mLyrics;


### PR DESCRIPTION
Hello Gareth,

Fix for songlist ticks for MAIN folder items disappearing if a set edit is used to change the set.  The root cause is 'doSave' and I have applied the MAIN folder handling to it, this gives healthy set handling / song list ticks (I believe!) - so MAIN is not added in the first place so we can revert to simpler code elsewhere.  Some other bits too.  Please test/consider.

Kind regards
Ian