### PR TITLE
HOTFIX: Performance mode needs to update song menu ticks after set load

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSetViewNew.java
@@ -454,6 +454,8 @@ public class PopUpSetViewNew extends DialogFragment {
 
         void prepareOptionMenu();
 
+        void prepareSongMenu();
+
         void confirmedAction();
 
         void refreshAll();
@@ -500,10 +502,11 @@ public class PopUpSetViewNew extends DialogFragment {
             mListener.windowFlags();
             mListener.pageButtonAlpha(null);
             // IV - For presentation mode refresh all
-            // IV - For performance modes only use onScrollAction to update the set buttons
+            // IV - For performance modes call prepareSongMenu to update song list which handles ticks and use onScrollAction to update the set buttons
             if (StaticVariables.whichMode.equals("Presentation")) {
                 mListener.refreshAll();
             } else {
+                mListener.prepareSongMenu();
                 mListener.onScrollAction();
             }
         }


### PR DESCRIPTION
Hello Gareth,

I am not having a good run.  Apologies but I have caused a further set tick issue(!) which my testing has now found.  With hindsight I should not have pushed other stuff with a root cause fix.  This commit is just a fix for the problem identified and I won't push more to my branch (not add to the pull) until you have collected.

In performance mode, set work updates the song menu (refreshes ticks) on dismiss.

Again my apologies.

Kind regards
Ian