### PR TITLE
Enh: String changes missing from recent commit

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
@@ -103,14 +103,14 @@ class Transpose {
     private final String[] fromchordsnum  = "├2┤ ├5┤ ├7┤ ├W┤ ├Y┤ ├1┤ ├3┤ ├4┤ ├6┤ ├8┤ ├9┤ ├X┤".split(" ");
     private final String[] tosharpchords1 = "»A# »C# »D# »F# »G# »»A »»B »»C »»D »»E »»F »»G".split(" ");
     private final String[] toflatchords1 =  "»Bb »Db »Eb »Gb »Ab »»A »»B »»C »»D »»E »»F »»G".split(" ");
-    private final String[] tosharpchords2 = "»»B »C# »D# »F# »G# »»A »»H »»C »»D »»E »»F »»G".split(" ");
+    private final String[] tosharpchords2 = "»A# »C# »D# »F# »G# »»A »»H »»C »»D »»E »»F »»G".split(" ");
     private final String[] toflatchords2 =  "»»B »Db »Eb »Gb »Ab »»A »»H »»C »»D »»E »»F »»G".split(" ");
     // IV - Solfege out format is 'SongSelect fixed DO' - Capitals = easy to read, no accents = easy to type, DO not UT and SI not TI = most common across solfege variants
     private final String[] tosharpchords4 = "LA# DO# RE# FA# «SOL# »LA »SI »DO »RE »MI »FA SOL".split(" ");
     private final String[] toflatchords4 =  "SIb REb MIb «SOLb LAb »LA »SI »DO »RE »MI »FA SOL".split(" ");
     //  A trick! Minors arrive ending ┤m, the m is moved into the number to give numbers for minors. '┤ma' is treated as the start of major and is protected.
     private final String[] fromchordsnumm = "┤ma ┤m ├2m┤ ├5m┤ ├7m┤ ├Wm┤ ├Ym┤ ├1m┤ ├3m┤ ├4m┤ ├6m┤ ├8m┤ ├9m┤ ├Xm┤ ├2┤ ├5┤ ├7┤ ├W┤ ├Y┤ ├1┤ ├3┤ ├4┤ ├6┤ ├8┤ ├9┤ ├X┤ ¬".split(" ");
-    private final String[] tosharpchords3 = "┤¬a m┤ »»»b »cis »dis »fis »gis »»»a »»»h »»»c »»»d »»»e »»»f »»»g »»B Cis Dis Fis Gis »»A »»H »»C »»D »»E »»F »»G m".split(" ");
+    private final String[] tosharpchords3 = "┤¬a m┤ »ais »cis »dis »fis »gis »»»a »»»h »»»c »»»d »»»e »»»f »»»g Ais Cis Dis Fis Gis »»A »»H »»C »»D »»E »»F »»G m".split(" ");
     private final String[] toflatchords3 =  "┤¬a m┤ »»»b »des »»es »ges »»as »»»a »»»h »»»c »»»d »»»e »»»f »»»g »»B Des »Es Ges »As »»A »»H »»C »»D »»E »»F »»G m".split(" ");
     private String[] fromchordnumsnash;
     private String[] fromchordnumsnashtype;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,7 +88,7 @@
     <string name="ccli_licence">Licence number</string>
     <string name="ccli_reset">Reset CCLI log</string>
     <string name="ccli_view">View CCLI log</string>
-    <string name="changestorage">Change OpenSong folder location</string>
+    <string name="changestorage">Select OpenSong folder location</string>
     <string name="chapter">Chapter</string>
     <string name="choose_app_mode">Choose app mode</string>
     <string name="choose_chordformat">Choose chord format</string>
@@ -732,7 +732,7 @@
     <string name="youtube">Search YouTube for current song</string>
     <string name="zerotime" translatable="false">0:00</string>
     <string name="duplicate">Duplicate</string>
-    <string name="storage_warning">Please do not select a folder within an \'OpenSong\' folder.  You should select the parent \'OpenSong\' folder instead.</string>
+    <string name="storage_warning">Please do not select a folder within an \'OpenSong\' folder.  You should select the parent \'OpenSong\' folder instead.</string>
     <string name="rotate_display">Rotate display</string>
     <string name="warn_before_changing_song">Show a warning before moving to the next song (useful to avoid accidental presses)</string>
     <string name="bold_chords_headings">Display chords and headings in bold</string>
@@ -754,8 +754,8 @@
     <string name="filter_section">Section filtering</string>
     <string name="filter_entry">Add each filter on a new line below.</string>
     <string name="filter_structure">[*filter:V] = filtered verse section</string>
-    <string name="storage_help">Please choose the location for your \'OpenSong\' folder.  This is the default storage location for OpenSong files.  You can change this at any time from the Options menu.  Internal storage is recommended.\n\nFor an update or re-install:\nYou can use the yellow button below to find any previous \'OpenSong\' folder.</string>
-    <string name="storage_quicktip">When selecting a location:\nList storage using the menu (you may need to change settings to show all storage).\nSELECT ONLY INTERNAL OR SD CARD storage.\nInternal storage is recommended.  This may list as device storage or with your device\'s name.\nOn Android 10+ you should not select the Downloads or Root folder.  If in doubt, choose the \'Documents\' folder.</string>
+    <string name="storage_help">Please select your \'OpenSong\' folder.  This is where songs, sets and more are stored.  If you need a new folder simply select a location for one to be added.  You can change the selected folder at any time from the Options menu.  Internal storage is recommended.\n\nFor an update or re-install:\nYou can use the yellow button below to find any previous OpenSong folder.</string>
+    <string name="storage_quicktip">When selecting an OpenSong folder location:\nSELECT ONLY INTERNAL OR SD CARD storage.\nInternal storage is recommended.  This may list as device storage or with your device\'s name.\nWhen selecting you may need to change settings to show all storage.\nOn Android 10+ you should not select the Downloads or Root folder.  If in doubt, choose the \'Documents\' folder.</string>
     <string name="information">Information</string>
     <string name="nearby_host_menu_only">Only listen for new clients when this page is visible</string>
     <string name="host">Host</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,8 +107,8 @@
     <string name="choosestickyfont">Choose sticky notes font</string>
     <string name="choosesongname">Choose a name for this song</string>
     <string name="chordFormat1" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/Bb  B</string>
-    <string name="chordFormat2" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  B   H</string>
-    <string name="chordFormat3" translatable="false">C  Cis/Des  D  Dis/Es  E  F  Fis/Ges  G  Gis/As  A  B  H</string>
+    <string name="chordFormat2" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/B   H</string>
+    <string name="chordFormat3" translatable="false">C  Cis/Des  D  Dis/Es  E  F  Fis/Ges  G  Gis/As  A  Ais/B  H</string>
     <string name="chordFormat4" translatable="false">DO  DO#/REb  RE  RE#/MIb  MI  FA  FA#/SOLb  SOL  SOL#/LAb  LA  LA#/SIb SI</string>
     <string name="chordFormat5" translatable="false">1  2  3  4  5  6  7  8  9  10  11  12</string>
     <string name="chordFormat6" translatable="false">I  II  III  IV  V  VI  VII  VIII  IX  X  XI  XII</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,9 +107,9 @@
     <string name="choosestickyfont">Choose sticky notes font</string>
     <string name="choosesongname">Choose a name for this song</string>
     <string name="chordFormat1" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/Bb  B</string>
-    <string name="chordFormat2" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/B   H</string>
+    <string name="chordFormat2" translatable="false">C  C#/Db  D  D#/Eb  E  F  F#/Gb  G  G#/Ab  A  A#/B  H</string>
     <string name="chordFormat3" translatable="false">C  Cis/Des  D  Dis/Es  E  F  Fis/Ges  G  Gis/As  A  Ais/B  H</string>
-    <string name="chordFormat4" translatable="false">DO  DO#/REb  RE  RE#/MIb  MI  FA  FA#/SOLb  SOL  SOL#/LAb  LA  LA#/SIb SI</string>
+    <string name="chordFormat4" translatable="false">DO  DO#/REb  RE  RE#/MIb  MI  FA  FA#/SOLb  SOL  SOL#/LAb  LA  LA#/SIb  SI</string>
     <string name="chordFormat5" translatable="false">1  2  3  4  5  6  7  8  9  10  11  12</string>
     <string name="chordFormat6" translatable="false">I  II  III  IV  V  VI  VII  VIII  IX  X  XI  XII</string>
     <string name="chord_color">Chords font</string>


### PR DESCRIPTION
Hello Gareth,

I missed some string changes.  This asks the user to select an 'OpenSong' folder and to create a new one if needed.   This seeks to position the app as the opener of 'OpenSong' folders - the user may have more than one, they can choose to sync, copy from another device etc.  For all these cases the app continues to open a selected 'OpenSong' folder in shared storage which is never part of the app.

On another point - I noticed a small typo in the store description.  

A song book app designed for **and** musicians, singers, worship leaders, 

Is it pragmatic to add songbook to the app title?  'OpenSongApp - Songbook', as a strap line of a core feature
A user searching for a songbook will not see the app as it is way down the list - this could help.

Kind regards
Ian

p.s. you will see some NBSP in the changes - My Android Studio has decided it will not render strings with double spaces in the preview!  Is yours the same?