### PR TITLE
Simplification of chord detect/preferred logic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -466,7 +466,7 @@
 
         <activity
             android:name="com.garethevans.church.opensongtablet.PresenterMode"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:configChanges="orientation|keyboard|keyboardHidden|screenSize|navigation"
             android:launchMode="singleTop"
             android:windowSoftInputMode="stateUnchanged" >
 
@@ -475,7 +475,7 @@
 
         <activity
             android:name="com.garethevans.church.opensongtablet.StageMode"
-            android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboard|keyboardHidden|screenSize|navigation"
             android:launchMode="singleTop">
 
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -1123,8 +1123,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                 ShowToast.showToast(c);
             } else {
                 try {
-                    // Detect and use the existing format for a 0 transpose
-                    Transpose.checkChordFormat();
+                    // Complete using a 0 transpose
                     StaticVariables.transposeDirection = "0";
                     StaticVariables.transposeTimes = 0;
                     transpose.doTranspose(c, preferences, true, false);
@@ -1151,8 +1150,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
             } else {
 
                 try {
-                    // Detect and use the existing format for transpose
-                    Transpose.checkChordFormat();
+                    // Complete using a 0 transpose
                     StaticVariables.transposeDirection = "0";
                     StaticVariables.transposeTimes = 0;
                     transpose.doTranspose(c,preferences, false, true);
@@ -1245,11 +1243,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                 StaticVariables.myToastMessage = c.getResources().getString(R.string.not_allowed);
                 ShowToast.showToast(c);
             } else {
-                // Detect the existing format and use for a 0 tranpose unless a preferred chord format is in use
-                Transpose.checkChordFormat();
-                if (preferences.getMyPreferenceInt(c,"chordFormat",0) > 0) {
-                    StaticVariables.newChordFormat = preferences.getMyPreferenceInt(c,"chordFormat",1);
-                }
+                // Complete using a 0 transpose
                 StaticVariables.transposeDirection = "0";
                 StaticVariables.transposeTimes = 0;
                 transpose.doTranspose(c, preferences, false, false);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpEditSongFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpEditSongFragment.java
@@ -602,8 +602,6 @@ public class PopUpEditSongFragment extends DialogFragment implements PopUpPresen
                 String selectedText = edit_song_lyrics.getText().toString().substring(startSelection, endSelection);
                 // Transpose it
                 try {
-                    // Detect and use the existing format for transpose
-                    Transpose.checkChordFormat();
                     StaticVariables.transposeDirection = "+1";
                     StaticVariables.transposeTimes = 1;
                     selectedText = transpose.transposeString(getContext(),preferences, selectedText, false, false);
@@ -629,8 +627,6 @@ public class PopUpEditSongFragment extends DialogFragment implements PopUpPresen
                 String selectedText = edit_song_lyrics.getText().toString().substring(startSelection, endSelection);
                 // Transpose it
                 try {
-                    // Detect and use the existing format for transpose
-                    Transpose.checkChordFormat();
                     StaticVariables.transposeDirection = "-1";
                     StaticVariables.transposeTimes = 1;
                     selectedText = transpose.transposeString(getContext(),preferences, selectedText, false, false);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpTransposeFragment.java
@@ -100,7 +100,6 @@ public class PopUpTransposeFragment extends DialogFragment {
         setListeners();
 
         // Initialise the transpose values
-        Transpose.checkChordFormat();
         StaticVariables.transposeDirection = "-1";
         StaticVariables.transposeTimes = 0;
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -3510,17 +3510,22 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                     FullscreenActivity.myLyrics = "";
                 }
 
-                // Note: If chordformat = 0 (detect) then chordFormatUsePreferred is false
-                try {
-                    if (preferences.getMyPreferenceBoolean(PresenterMode.this,"chordFormatUsePreferred",true)) {
-                        StaticVariables.detectedChordFormat = preferences.getMyPreferenceInt(PresenterMode.this,"chordFormat",1);
+                if (FullscreenActivity.isSong) {
+                    // Detemine formats to be used for capo / transpose
+                    // Note: If chordformat = 0 (detect) then chordFormatUsePreferred is false
+                    try {
+                        if (preferences.getMyPreferenceBoolean(PresenterMode.this, "chordFormatUsePreferred", true)) {
+                            // Set StaticVariables.detectedChordFormat to the preferred format
+                            StaticVariables.detectedChordFormat = preferences.getMyPreferenceInt(PresenterMode.this, "chordFormat", 1);
+                        } else {
+                            // Sets StaticVariables.detectedChordFormat to the detected format
+                            Transpose.checkChordFormat();
+                        }
+                        // Set the newChordFormat default to be the same
                         StaticVariables.newChordFormat = StaticVariables.detectedChordFormat;
-                    } else {
-                        // CheckChordFormat returns the current format to both StaticVariables detectedChordFormat and newChordFormat
-                        Transpose.checkChordFormat();
+                    } catch (Exception e) {
+                        Log.d(TAG, "Error checking the chord format");
                     }
-                } catch (Exception e) {
-                    Log.d(TAG, "Error checking the chord format");
                 }
 
                 // Don't process images or image slide details here.  No need.  Only do songs

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ProcessSong.java
@@ -73,6 +73,7 @@ public class ProcessSong extends Activity {
     private Typeface typefaceChords;
     private Typeface typefacePreso;
     private Typeface typefaceMono;
+    private final Transpose transpose = new Transpose();
 
     static void processTimeSig() {
         switch (StaticVariables.mTimeSig) {
@@ -1915,7 +1916,6 @@ public class ProcessSong extends Activity {
             }
             // IV - Get the capokey here to support later getCapoNewKey call
             if (StaticVariables.mKey != null) {
-                Transpose transpose = new Transpose();
                 transpose.capoKeyTranspose(c, preferences);
             }
         }
@@ -2148,9 +2148,6 @@ public class ProcessSong extends Activity {
                                  int lyricsVerseColor, int lyricsChorusColor,
                                  int lyricsPreChorusColor, int lyricsBridgeColor, int lyricsTagColor) {
 
-        Transpose transpose = new Transpose();
-        // Added in chord format check otherwise app gets stuck with detected format
-        Transpose.checkChordFormat();
         getPreferences(c, preferences);
 
         // Decide if chords are valid to be shown
@@ -2409,9 +2406,6 @@ public class ProcessSong extends Activity {
                                       Preferences preferences,
                                       int lyricsTextColor, int lyricsChordsColor,
                                       int lyricsCapoColor, int presoFontColor, int presoShadowColor) {
-        Transpose transpose = new Transpose();
-        // Added in chord format check otherwise app gets stuck with detected format
-        Transpose.checkChordFormat();
 
         getPreferences(c, preferences);
 
@@ -3049,7 +3043,6 @@ public class ProcessSong extends Activity {
                     }
 
                     if (!StaticVariables.mKey.equals("")) {
-                        Transpose transpose = new Transpose();
                         transpose.capoKeyTranspose(c, preferences);
                         songInformation.append(" (").append(FullscreenActivity.capokey).append(")");
                     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -7302,15 +7302,18 @@ public class StageMode extends AppCompatActivity implements
                 FullscreenActivity.foundSongSections_heading = new ArrayList<>();
 
                 if (FullscreenActivity.isSong) {
+                    // Detemine formats to be used for capo / transpose
                     // Note: If chordformat = 0 (detect) then chordFormatUsePreferred is false
                     try {
                         if (preferences.getMyPreferenceBoolean(StageMode.this,"chordFormatUsePreferred",true)) {
+                            // Set StaticVariables.detectedChordFormat to the preferred format
                             StaticVariables.detectedChordFormat = preferences.getMyPreferenceInt(StageMode.this,"chordFormat",1);
-                            StaticVariables.newChordFormat = StaticVariables.detectedChordFormat;
                         } else {
-                            // CheckChordFormat returns the current format to both StaticVariables detectedChordFormat and newChordFormat
+                            // Sets StaticVariables.detectedChordFormat to the detected format
                             Transpose.checkChordFormat();
                         }
+                        // Set the newChordFormat default to be the same
+                        StaticVariables.newChordFormat = StaticVariables.detectedChordFormat;
                     } catch (Exception e) {
                         Log.d(TAG, "Error checking the chord format");
                     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/Transpose.java
@@ -631,8 +631,6 @@ class Transpose {
         else if (contains_nash)                 StaticVariables.detectedChordFormat = 5;
         else if (contains_nashnumeral)          StaticVariables.detectedChordFormat = 6;
         else                                    StaticVariables.detectedChordFormat = 1;
-        // We set the newChordFormat default to the same as detected
-        StaticVariables.newChordFormat = StaticVariables.detectedChordFormat;
     }
 
     void writeImprovedXML (Context c, Preferences preferences) {


### PR DESCRIPTION
Hello Gareth,

This commit changes to chord detect / preferred format use logic in the song load only, there is no need to do it again.  This removes detect calls from lots of other places.  As the chord/preferred settings cannot change doing it once is good. 

A user wishing to run without detection (they know they only want one format) can set a preferred format and let transpose use the same preferred format.  We know, because the logic is only in song load, preferred is used and detect is not run.

For a recent issue with German transpose - setting preferred to German and transpose to preferred would have 'in' and 'out' as German which will reliably work.  German format is too close to Standard to rely on detect.

It is less code!  Please consider.

Kind regards
Ian


