### PR TITLE
Fix: Bugs of not requesting rebuild of song menu

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ChordProConvert.java
@@ -77,9 +77,6 @@ class ChordProConvert {
         writeTheImprovedSong(c, storageAccess, preferences, oldSongFileName, newSongFileName,
                 songSubFolder, newUri, uri);
 
-        // Indicate after loading song (which renames it), we need to build the database and song index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         return bitsForIndexing(newSongFileName, title, author, copyright, key, time_sig, ccli, lyrics);
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/ImportIntent.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ImportIntent.java
@@ -229,7 +229,6 @@ public class ImportIntent extends AppCompatActivity implements PopUpImportExport
     private void rebuildSearchIndex() {
         Log.d("d", "rebuildSearchIndex called");
         FullscreenActivity.whattodo = "";
-        FullscreenActivity.needtorefreshsongmenu = false;
         // If the app is already running, send the call to run BootUpCheck
         if (FullscreenActivity.appRunning) {
             // Close this intent and send the listener to rebuild inded

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -566,7 +566,6 @@ public class NearbyConnections implements NearbyInterface {
                     // Write the file to the desired output stream and load
                     if (nearbyReturnActionsInterface != null) {
                         storageAccess.writeFileFromString(receivedBits.get(3), outputStream);
-                        nearbyReturnActionsInterface.prepareSongMenu();
                         StaticVariables.currentSection = pendingCurrentSection;
                         nearbyReturnActionsInterface.loadSong();
                     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OnSongConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OnSongConvert.java
@@ -104,9 +104,6 @@ class OnSongConvert {
         chordProConvert.writeTheImprovedSong(c, storageAccess, preferences, oldSongFileName, newSongFileName,
                 songSubFolder, newUri, uri);
 
-        // Indicate after loading song (which renames it), we need to build the database and song index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         // Add it to the database
         return chordProConvert.bitsForIndexing(newSongFileName, title, author, copyright, key, time_sig, ccli, lyrics);
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpEditSongFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpEditSongFragment.java
@@ -249,7 +249,6 @@ public class PopUpEditSongFragment extends DialogFragment implements PopUpPresen
             // Now tell the main page to refresh itself with this new song
             // Don't need to reload the XML as we already have all its values
             mListener.loadSong();
-            mListener.prepareSongMenu();
 
             // Now dismiss this popup
             forceHideKeyboard();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpFindNewSongsFragment.java
@@ -1528,9 +1528,6 @@ public class PopUpFindNewSongsFragment extends DialogFragment {
             StaticVariables.songfilename = nameofpdffile;
         }
 
-        // Indicate after loading song (which renames it), we need to build the database and song index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         if (mListener != null) {
             mListener.loadSong();
             // IV - Moved after load to better report details of the song

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExternalFile.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExternalFile.java
@@ -531,10 +531,6 @@ public class PopUpImportExternalFile extends DialogFragment {
             filename = filename.replace(".ost","");
         }
 
-
-        // Set the variable to initialise the search index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         // Copy the file
         copyFile("Songs", chosenfolder, filename);
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLongSongPressFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpLongSongPressFragment.java
@@ -195,8 +195,6 @@ public class PopUpLongSongPressFragment extends DialogFragment {
     @Override
     public void onDismiss(@NonNull final DialogInterface dialog) {
         if (mListener!=null) {
-            // IV - Force an update of the song menu
-            FullscreenActivity.needtorefreshsongmenu = true;
             mListener.prepareSongMenu();
         }
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongCreateFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongCreateFragment.java
@@ -171,8 +171,6 @@ public class PopUpSongCreateFragment extends DialogFragment {
 
         @Override
         protected void onPreExecute() {
-            // Prepare the app to rebuild the search index after loading the song
-            FullscreenActivity.needtorefreshsongmenu = true;
             tempNewSong = newSongNameEditText.getText().toString().trim();
             tempNewSong = storageAccess.safeFilename(tempNewSong);
             newSongNameEditText.setText(tempNewSong);
@@ -234,7 +232,6 @@ public class PopUpSongCreateFragment extends DialogFragment {
 
                     try {
                         if (mListener != null) {
-                            mListener.prepareSongMenu();
                             Log.d("PopUpCreate", "setting songfilename=" + tempNewSong);
                             StaticVariables.songfilename = tempNewSong;
                             Log.d("PopUpCreate", "setting whichSongFolder=" + FullscreenActivity.newFolder);
@@ -311,15 +308,18 @@ public class PopUpSongCreateFragment extends DialogFragment {
 
         protected void onPostExecute(String s) {
             try {
+                // IV - Store song details
+                preferences.setMyPreferenceString(getContext(), "songfilename",StaticVariables.songfilename);
+                preferences.setMyPreferenceString(getContext(),"whichSongFolder",StaticVariables.whichSongFolder);
+
                 if (!StaticVariables.myToastMessage.equals(getString(R.string.error)) &&
                         !StaticVariables.myToastMessage.equals(getString(R.string.notset)) &&
                         !StaticVariables.myToastMessage.equals(getString(R.string.songnamealreadytaken))) {
 
                     if (mListener != null) {
-                        mListener.prepareSongMenu();
                         if (!FullscreenActivity.whattodo.equals("savecameraimage")) {
                             // Prepare the app to open the edit page after loading
-                            FullscreenActivity.needtorefreshsongmenu = false;  // This will happen after editing
+                            FullscreenActivity.needtorefreshsongmenu = false;  // Used to avoid two full song menu builds, one will happen after editing
                             FullscreenActivity.needtoeditsong = true;
                         }
                         mListener.loadSong();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongFolderRenameFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongFolderRenameFragment.java
@@ -210,9 +210,6 @@ public class PopUpSongFolderRenameFragment extends DialogFragment {
 
                 progressBar.setVisibility(View.GONE);
 
-                // Let the app know we need to rebuild the database
-                FullscreenActivity.needtorefreshsongmenu = true;
-
                 if (mListener != null) {
                     mListener.loadSong();
                 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongRenameFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongRenameFragment.java
@@ -109,8 +109,8 @@ public class PopUpSongRenameFragment extends DialogFragment {
                     sqLite.setSongid(songId);
                     sqLite.setFolder(StaticVariables.whichSongFolder);
                     sqLite.setFilename(StaticVariables.songfilename);
-                    sqLiteHelper.updateSong(getContext(), sqLite);
                 }
+                sqLiteHelper.updateSong(getContext(), sqLite);
 
                 if (mListener!=null) {
                     mListener.loadSong();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongRenameFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpSongRenameFragment.java
@@ -112,10 +112,8 @@ public class PopUpSongRenameFragment extends DialogFragment {
                     sqLiteHelper.updateSong(getContext(), sqLite);
                 }
 
-                FullscreenActivity.needtorefreshsongmenu = true;
                 if (mListener!=null) {
                     mListener.loadSong();
-                    mListener.prepareSongMenu();
                 }
             } catch (Exception e) {
                 Log.d("d", "Error renaming");

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -3681,19 +3681,25 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         FullscreenActivity.alreadyloading = false;
                     }
 
-                    // Get the SQLite stuff if the song exists.  Otherwise throws an exception (which is ok)
+                    // Get the SQLite stuff
                     if (!StaticVariables.whichSongFolder.startsWith("..")) {
                         String songId = StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename;
 
                         if (FullscreenActivity.isPDF || FullscreenActivity.isImage) {
                             nonOpenSongSQLite = nonOpenSongSQLiteHelper.getSong(PresenterMode.this,storageAccess,preferences,songId);
-                        } else {
-                            // If this song isn't indexed, set its details
+                        }
+                        sqLite = sqLiteHelper.getSong(PresenterMode.this, songId);
+
+                        // IV - Backstop, if the song is not found add a basic song entry. Handles Nearby 'imported' songs
+                        if (sqLite == null) {
+                            sqLiteHelper.createImportedSong(PresenterMode.this, StaticVariables.whichSongFolder, StaticVariables.songfilename, StaticVariables.songfilename, "", "", "", "", "", "");
                             sqLite = sqLiteHelper.getSong(PresenterMode.this, songId);
-                            if (sqLite.getLyrics()==null || sqLite.getLyrics().equals("")) {
-                                sqLite = sqLiteHelper.setSong(sqLite);
-                                sqLiteHelper.updateSong(PresenterMode.this,sqLite);
-                            }
+                        }
+
+                        // If this song isn't indexed, set its details
+                        if (sqLite.getLyrics()==null || sqLite.getLyrics().equals("")) {
+                            sqLite = sqLiteHelper.setSong(sqLite);
+                            sqLiteHelper.updateSong(PresenterMode.this,sqLite);
                         }
                     } else {
                         // Not a song in the database (likley a variation, slide, etc.)

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -778,6 +778,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         if (song_list_view != null) {
             try {
                 if (menuFolder_TextView.getText() != null) {
+                    // IV - FullscreenActivity.needtorefreshsongmenu can be set false before a call to try to use the existing song menu
                     if (!FullscreenActivity.needtorefreshsongmenu && menuFolder_TextView.getText().toString().equals(StaticVariables.whichSongFolder)) {
                         findSongInFolders();
                     } else {
@@ -791,6 +792,8 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                 e.printStackTrace();
             }
         }
+        // IV - Reset to ensure the default behaviour is true
+        FullscreenActivity.needtorefreshsongmenu = true;
     }
 
     private void checkBackupState() {
@@ -857,16 +860,20 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         // Save our preferences
         saveFileLocation(clickedfile, clickedfolder);
 
-        // Load the song
-        loadSong();
+        // Allow drawer close animation time to cleanly complete
+        Handler delayloadsong = new Handler();
+        delayloadsong.postDelayed(() -> {
+            FullscreenActivity.needtorefreshsongmenu = false;
+            loadSong();
 
-        FullscreenActivity.currentSongIndex = i;
+            FullscreenActivity.currentSongIndex = i;
 
-        // Scroll to this song in the song menu
-        song_list_view.smoothScrollToPosition(i);
+            // Scroll to this song in the song menu
+            song_list_view.smoothScrollToPosition(i);
 
-        // Initialise the previous and next songs
-        findSongInFolders();
+            // Initialise the previous and next songs
+            findSongInFolders();
+        }, 300);
     }
 
     @Override
@@ -899,8 +906,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         closeMyDrawers("song");
         // IV - prepareOptionMenu also prepares the set list
         prepareOptionMenu();
-        // IV - Force update the song menu
-        FullscreenActivity.needtorefreshsongmenu = true;
         prepareSongMenu();
         fixSet();
     }
@@ -1486,7 +1491,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                 // Close the drawers in case they are open
                 closeMyDrawers("both");
 
-                FullscreenActivity.needtorefreshsongmenu = true;
                 // IV - we cannot determine the index so go to top
                 FullscreenActivity.currentSongIndex = 0;
 
@@ -1852,8 +1856,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                     sqLiteHelper.deleteSong(PresenterMode.this, sqLite.getSongid());
                 }
 
-                FullscreenActivity.needtorefreshsongmenu = true;
-
                 // IV - Load song to display as deleted
                 loadSong();
                 break;
@@ -1960,6 +1962,8 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     // Loading the song
     @Override
     public void loadSongFromSet() {
+        FullscreenActivity.needtorefreshsongmenu = false;
+
         // Redraw the set buttons as the user may have changed the order
         refreshAll();
 
@@ -2095,10 +2099,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         @Override
         protected void onPostExecute(String s) {
             showToastMessage(getString(R.string.search_index_end));
-
-            FullscreenActivity.needtorefreshsongmenu = true;
-
-            // Update the song menu
             prepareSongMenu();
         }
     }
@@ -2998,8 +2998,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         presenter_set_buttonsListView.removeAllViews();
         presenter_song_buttonsListView.removeAllViews();
         presenter_lyrics.setText("");
-        FullscreenActivity.needtorefreshsongmenu = true;
-        prepareSongMenu();
         setupPageButtons();
         prepareOptionMenu();
         fixSet();
@@ -3573,6 +3571,10 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         StaticVariables.currentSection = -(1 + StaticVariables.currentSection);
                     }
                     FullscreenActivity.pdfPageCurrent = StaticVariables.currentSection;
+                } else {
+                    // IV - For a reload, load the stored whichSongFolder in case we were browsing elsewhere
+                    StaticVariables.whichSongFolder = preferences.getMyPreferenceString(PresenterMode.this,"whichSongFolder", getString(R.string.mainfoldername));
+                    FullscreenActivity.needtorefreshsongmenu = false;
                 }
 
                 // Clear the old headings (presention order looks for these)
@@ -3722,8 +3724,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             menuCount_TextView.setVisibility(View.GONE);
             menuFolder_TextView.setText(getString(R.string.wait));
             song_list_view.setAdapter(null);
-            // IV - This is set false when the refresh suceeeds
-            FullscreenActivity.needtorefreshsongmenu = true;
             LinearLayout indexLayout = findViewById(R.id.side_index);
             indexLayout.removeAllViews();
         }
@@ -3764,11 +3764,15 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
 
                     for (int i=0; i<songsInFolder.size(); i++) {
                         String foundsongfilename = songsInFolder.get(i).getFilename();
+                        String foundsongtitle = songsInFolder.get(i).getTitle();
                         String foundsongauthor = songsInFolder.get(i).getAuthor();
                         String foundsongkey = songsInFolder.get(i).getKey();
 
                         if (foundsongfilename == null) {
                             foundsongfilename = getString(R.string.error);
+                        }
+                        if (foundsongtitle == null || foundsongtitle.equals("")) {
+                            foundsongtitle = foundsongfilename;
                         }
                         if (foundsongauthor == null) {
                             foundsongauthor = "";
@@ -3813,7 +3817,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         menuCount_TextView.setText(menusize);
                         menuCount_TextView.setVisibility(View.VISIBLE);
                     }
-                    FullscreenActivity.needtorefreshsongmenu = false;
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -3790,6 +3790,8 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         boolean isinset = setcurrent.contains(whattolookfor);
 
                         SongMenuViewItems song = new SongMenuViewItems(foundsongfilename,
+                                //TODO GE commit changes to display of title  however SQL does not yet order by title. Both filename and title order, user choice, are needed.
+                                //foundsongtitle, foundsongauthor, foundsongkey, isinset);
                                 foundsongfilename, foundsongauthor, foundsongkey, isinset);
                         songmenulist.add(song);
                     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -1856,6 +1856,9 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                     sqLiteHelper.deleteSong(PresenterMode.this, sqLite.getSongid());
                 }
 
+                // IV - Force a song menu refresh as we have deleted a song
+                prepareSongMenu();
+
                 // IV - Load song to display as deleted
                 loadSong();
                 break;
@@ -3654,7 +3657,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         LoadXML.getPDFPageCount(PresenterMode.this, preferences, storageAccess);
                     }
                     setupSongButtons();
-                    prepareSongMenu();
 
                     // Send the midi data if we can
                     if (!orientationChanged) {
@@ -3698,6 +3700,9 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
                         sqLite.setSongid("");
                         sqLite.setId(0);
                     }
+
+                    // IV - After any sqLite update has occurred
+                    prepareSongMenu();
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/SQLiteHelper.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/SQLiteHelper.java
@@ -317,6 +317,7 @@ class SQLiteHelper extends SQLiteOpenHelper {
 
         // Select matching folder Query
         String selectQuery = "SELECT "+SQLite.COLUMN_FILENAME + ", " +
+                SQLite.COLUMN_TITLE + ", " +
                 SQLite.COLUMN_AUTHOR + ", " +
                 SQLite.COLUMN_KEY + " " +
                 "FROM " + SQLite.TABLE_NAME +
@@ -331,6 +332,7 @@ class SQLiteHelper extends SQLiteOpenHelper {
                 do {
                     SQLite sqLite = new SQLite();
                     sqLite.setFilename(unescapedSQL(cursor.getString(cursor.getColumnIndex(SQLite.COLUMN_FILENAME))));
+                    sqLite.setTitle(unescapedSQL(cursor.getString(cursor.getColumnIndex(SQLite.COLUMN_TITLE))));
                     sqLite.setAuthor(unescapedSQL(cursor.getString(cursor.getColumnIndex(SQLite.COLUMN_AUTHOR))));
                     sqLite.setKey(unescapedSQL(cursor.getString(cursor.getColumnIndex(SQLite.COLUMN_KEY))));
                     if (!sqLite.getFilename().equals("") && !files.contains("$__" + sqLite.getFolder() + "/" + sqLite.getFilename() + "__$")) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/SetActions.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/SetActions.java
@@ -995,6 +995,8 @@ class SetActions {
             getSongFileAndFolder(c);
 
             StaticVariables.setMoveDirection = "";
+
+            FullscreenActivity.needtorefreshsongmenu = false;
             mListener.loadSong();
         }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -7759,6 +7759,8 @@ public class StageMode extends AppCompatActivity implements
                         boolean isinset = setcurrent.contains(whattolookfor);
 
                         SongMenuViewItems song = new SongMenuViewItems(foundsongfilename,
+                                //TODO GE commit changes to display of title  however SQL does not yet order by title. Both filename and title order, user choice, are needed.
+                                //foundsongtitle, foundsongauthor, foundsongkey, isinset);
                                 foundsongfilename, foundsongauthor, foundsongkey, isinset);
                         songmenulist.add(song);
                         filenamesSongsInFolder.add(foundsongfilename);

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -7546,16 +7546,27 @@ public class StageMode extends AppCompatActivity implements
                     // Get the SQLite stuff
                     if (!StaticVariables.whichSongFolder.startsWith("..")) {
                         String songId = StaticVariables.whichSongFolder + "/" + StaticVariables.songfilename;
+
                         if (FullscreenActivity.isPDF || FullscreenActivity.isImage) {
                             nonOpenSongSQLite = nonOpenSongSQLiteHelper.getSong(StageMode.this, storageAccess, preferences, songId);
                         }
                         sqLite = sqLiteHelper.getSong(StageMode.this, songId);
+
+                        // IV - Backstop, if the song is not found add a basic song entry. Handles Nearby 'imported' songs
+                        if (sqLite==null) {
+                            sqLiteHelper.createImportedSong(StageMode.this, StaticVariables.whichSongFolder, StaticVariables.songfilename, StaticVariables.songfilename, "", "", "", "", "", "");
+                            sqLite = sqLiteHelper.getSong(StageMode.this, songId);
+                        }
 
                         // If this song isn't indexed, set its details
                         if (sqLite!=null && (sqLite.getLyrics()==null || sqLite.getLyrics().equals(""))) {
                             sqLite = sqLiteHelper.setSong(sqLite);
                             sqLiteHelper.updateSong(StageMode.this,sqLite);
                         }
+                    } else {
+                        // Not a song in the database (likley a variation, slide, etc.)
+                        sqLite.setSongid("");
+                        sqLite.setId(0);
                     }
 
                     // IV - After any sqLite update has occurred

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -3311,6 +3311,10 @@ public class StageMode extends AppCompatActivity implements
                 if (sqLite!=null && sqLite.getSongid()!=null) {
                     sqLiteHelper.deleteSong(StageMode.this, sqLite.getSongid());
                 }
+
+                // IV - Force a song menu refresh as we have deleted a song
+                prepareSongMenu();
+
                 // IV - Load previous song to keep place in list
                 goToPreviousItem();
 
@@ -7530,8 +7534,6 @@ public class StageMode extends AppCompatActivity implements
                         }
                     }
 
-                    prepareSongMenu();
-
                     delayactionBarHide.removeCallbacks(hideActionBarRunnable);
                     if (preferences.getMyPreferenceBoolean(StageMode.this,"hideActionBar",false)) {
                         delayactionBarHide.postDelayed(hideActionBarRunnable, 1000);
@@ -7555,6 +7557,10 @@ public class StageMode extends AppCompatActivity implements
                             sqLiteHelper.updateSong(StageMode.this,sqLite);
                         }
                     }
+
+                    // IV - After any sqLite update has occurred
+                    prepareSongMenu();
+
                     // Make sure all dynamic (scroll and set) buttons display
                     onScrollAction();
                 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/TextSongConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/TextSongConvert.java
@@ -42,9 +42,6 @@ class TextSongConvert {
         // Remove any blank headings if they are redundant
         compiledtext = fixBlankHeadings(c, compiledtext);
 
-        // Indicate after loading song (which renames it), we need to build the database and song index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         return compiledtext;
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/UsrConvert.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/UsrConvert.java
@@ -62,9 +62,6 @@ class UsrConvert {
         chordProConvert.writeTheImprovedSong(c, storageAccess, preferences, oldSongFileName, newSongFileName,
                 songSubFolder, newUri, uri);
 
-        // Indicate after loading song (which renames it), we need to build the database and song index
-        FullscreenActivity.needtorefreshsongmenu = true;
-
         return chordProConvert.bitsForIndexing(newSongFileName, title, author, copyright, key, time_sig, ccli, lyrics);
 
     }

--- a/app/src/main/res/layout/popup_option_display.xml
+++ b/app/src/main/res/layout/popup_option_display.xml
@@ -129,32 +129,6 @@
             android:textColor="#fff"
             android:textSize="12sp" />
 
-        <Button
-            android:id="@+id/gesturesMenuOptions"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="2dp"
-            android:background="@drawable/menu_button"
-            android:drawableStart="@drawable/ic_menuswipe_white_36dp"
-            android:drawablePadding="4dp"
-            android:gravity="center_vertical"
-            android:text="@string/menu_settings"
-            android:textColor="#fff"
-            android:textSize="12sp" />
-
-        <Button
-            android:id="@+id/gesturesSongSwipeButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="2dp"
-            android:background="@drawable/menu_button"
-            android:drawableStart="@drawable/ic_swipe_white_36dp"
-            android:drawablePadding="4dp"
-            android:gravity="center_vertical"
-            android:text="@string/swipe"
-            android:textColor="#fff"
-            android:textSize="12sp" />
-
         <TextView
             android:id="@+id/button_separator_textview"
             android:layout_width="match_parent"
@@ -202,6 +176,19 @@
             android:textSize="12sp" />
 
         <Button
+            android:id="@+id/gesturesMenuOptions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="2dp"
+            android:background="@drawable/menu_button"
+            android:drawableStart="@drawable/ic_menuswipe_white_36dp"
+            android:drawablePadding="4dp"
+            android:gravity="center_vertical"
+            android:text="@string/menu_settings"
+            android:textColor="#fff"
+            android:textSize="12sp" />
+
+        <Button
             android:id="@+id/displayPopUpsButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -211,6 +198,19 @@
             android:drawablePadding="4dp"
             android:gravity="center_vertical"
             android:text="@string/display_popups"
+            android:textColor="#fff"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/gesturesSongSwipeButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="2dp"
+            android:background="@drawable/menu_button"
+            android:drawableStart="@drawable/ic_swipe_white_36dp"
+            android:drawablePadding="4dp"
+            android:gravity="center_vertical"
+            android:text="@string/swipe"
             android:textColor="#fff"
             android:textSize="12sp" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -546,7 +546,7 @@
     <string name="storage_check">Checking storage</string>
     <string name="storage_choose">Manage storage</string>
     <string name="storage_ext">External storage</string>
-    <string name="storage_notwritable">"Android does not allow use of an OpenSong folder in this location - choose a different location.  Click the (?) button for advice.</string>
+    <string name="storage_notwritable">Android does not allow use of an OpenSong folder in this location - choose a different location.  Click the (?) button for advice.</string>
     <string name="storage_rationale">Access to your storage is required to read and write songs and sets.</string>
     <string name="subscription">(Subscription required)</string>
     <string name="success">Success</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@
     <string name="current_category">Current category</string>
     <string name="currentkeycode">Current keycode</string>
     <string name="currentset">Current set</string>
-    <string name="currentstorage">Selected location</string>
+    <string name="currentstorage">Location</string>
     <string name="custom">Custom</string>
     <string name="custom1_theme">Custom 1</string>
     <string name="custom2_theme">Custom 2</string>
@@ -546,7 +546,7 @@
     <string name="storage_check">Checking storage</string>
     <string name="storage_choose">Manage storage</string>
     <string name="storage_ext">External storage</string>
-    <string name="storage_notwritable">Android does not allow use of an OpenSong folder in this location - choose a different location.  Click the (?) button for advice.</string>
+    <string name="storage_notwritable">Android requires you to select the location to allow it to be used by OpenSongApp.\nClick the (?) button for further advice.</string>
     <string name="storage_rationale">Access to your storage is required to read and write songs and sets.</string>
     <string name="subscription">(Subscription required)</string>
     <string name="success">Success</string>


### PR DESCRIPTION
Hello Gareth,

Found more cases where re-use of the song menu happens when it should not - I have reversed the default of prepareSongMenu to be full rebuild and changed code so that we explicitly request re-use.  This is safe as a forgotten request to re-use means a full rebuild which is still good.  Previously a forgotten request for full rebuild resulted in re-use which is bad.  This way round we are more bug tolerant!   A few other fixes and bits too!

Kind regards
Ian