### PR TITLE
Enh: Check device location services are ON,  before opening connect devices. Export set list comma fix

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/ExportPreparer.java
@@ -456,7 +456,8 @@ class ExportPreparer {
                                         // Read in the song title, author, copyright, hymnnumber, key
                                         getSongData(c, songuri, storageAccess);
                                     }
-                                    sb.append(song_title);
+                                    // IV - Handle comma in name - remove comma with no following space as used in numbers - '10,000 Reasons'
+                                    sb.append(song_title.replace(", "," | ").replace(",",""));
                                     sb.append("¬ ");
                                     if (!song_author.isEmpty()) {
                                         sb.append(song_author);
@@ -528,7 +529,7 @@ class ExportPreparer {
         }
 
         // Send the settext back to the FullscreenActivity as emailtext
-        // IV - , (comma) is the delimiter so use within content is replaced with " |" and the the temporary delimeter ¬ replaced with ,
+        // IV - , (comma) is the delimiter so use within content is replaced with " |" and then the temporary delimeter ¬ replaced with ,
         FullscreenActivity.emailtext = sb.toString().replace(","," |").replace("¬",",");
         FullscreenActivity.exportsetfilenames = filesinset;
         FullscreenActivity.exportsetfilenames_ost = filesinset_ost;
@@ -542,7 +543,7 @@ class ExportPreparer {
 		song_author = "";
         song_hymnnumber = "";
         song_ccli = "";
-		song_key = "";
+        song_key = "";
 
 
 		// Get inputtream for the song

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Stop ontdekking"</string>
     <string name="connections_failure">"Konneksie mislukking"</string>
     <string name="connections_host">"Gevind gasheer:"</string>
-    <string name="connections_log">"Verbinding log (kliek om te verwyder). As jy enige probleme het, herstel jou WiFi en herbegin die program."</string>
+    <string name="connections_log">Verbinding log (kliek om te verwyder). As jy enige probleme het, herstel jou W-iFi en herbegin die program.</string>
     <string name="connections_receive_host">"Ontvang gasheer liedjies"</string>
     <string name="connections_searching">"Soek …"</string>
     <string name="connections_service_start">"Begin diens"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Jy moet 'n nuwer weergawe van Android vir hierdie !"</string>
     <string name="notsaved">nie gestoor nie</string>
     <string name="notset">"Nie ingestel"</string>
-    <string name="nowifidirect">"Jammer, hierdie toestel ondersteun nie WiFi direkte nie"</string>
+    <string name="nowifidirect">Jammer, hierdie toestel ondersteun nie Wi-Fi direkte nie</string>
     <string name="off">"Af"</string>
     <string name="ok">"Ok"</string>
     <string name="oldchordformat">"Bespeur huidige koord formaat"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI vertraging buffer</string>
     <string name="forum">Help (googlegroups)</string>
     <string name="songs">Liedjies</string>
+    <string name="location_not_enabled">Skakel asseblief \'Ligging\' AAN om aan toestelle te koppel. As jy \'n keuse van modus het, kies \'n modus wat Wi-Fi gebruik.</string>
+    <string name="location">Ligging</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Zastavte objev"</string>
     <string name="connections_failure">"Selhání připojení"</string>
     <string name="connections_host">"Nalezeno hostitele:"</string>
-    <string name="connections_log">"Protokol připojení (klepnutím zrušte). Pokud máte nějaké problémy, obnovte WiFi a restartujte aplikaci."</string>
+    <string name="connections_log">Protokol připojení (klepnutím zrušte). Pokud máte nějaké problémy, obnovte Wi-Fi a restartujte aplikaci.</string>
     <string name="connections_receive_host">"Přijměte hostující skladby"</string>
     <string name="connections_searching">"Hledání …"</string>
     <string name="connections_service_start">"Spusťte službu"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Potřebujete novější verzi Androidu pro to !"</string>
     <string name="notsaved">"neuloženo"</string>
     <string name="notset">"Není stanoveno"</string>
-    <string name="nowifidirect">"Je nám líto, ale toto zařízení nepodporuje WiFi přímo"</string>
+    <string name="nowifidirect">Je nám líto, ale toto zařízení nepodporuje Wi-Fi přímo</string>
     <string name="off">"Vypnuto"</string>
     <string name="ok">"Dobrá."</string>
     <string name="oldchordformat">"Zjištěno Současný formát akord"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI delay buffer</string>
     <string name="forum">Help (googlegroups)</string>
     <string name="songs">Písně</string>
+    <string name="location_not_enabled">Chcete-li se připojit k zařízením, zapněte \'Poloha\'. Pokud máte na výběr režim, vyberte režim, který využívá Wi-Fi.</string>
+    <string name="location">Poloha</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Suche beenden"</string>
     <string name="connections_failure">"Verbindungsfehler"</string>
     <string name="connections_host">"Gefundener Host:"</string>
-    <string name="connections_log">"Verbindungsprotokoll (zum Löschen klicken). Wenn Sie irgendwelche Probleme haben, setzen Sie Ihr WiFi zurück und starten Sie die App neu."</string>
+    <string name="connections_log">Verbindungsprotokoll (zum Löschen klicken). Wenn Sie irgendwelche Probleme haben, setzen Sie Ihr Wi-Fi zurück und starten Sie die App neu.</string>
     <string name="connections_receive_host">"Host-Songs empfangen"</string>
     <string name="connections_searching">"Suchen …"</string>
     <string name="connections_service_start">"Dienst starten"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Sie benötigen eine neuere Android-Version für diese Aktion"</string>
     <string name="notsaved">Nicht gespeichert</string>
     <string name="notset">"Nicht gesetzt"</string>
-    <string name="nowifidirect">"Entschuldigung, dieses Gerät unterstützt WiFi direct nicht"</string>
+    <string name="nowifidirect">Entschuldigung, dieses Gerät unterstützt Wi-Fi direct nicht</string>
     <string name="off">"Aus"</string>
     <string name="ok">"OK"</string>
     <string name="oldchordformat">"Aktuelles Akkord-Format ermitteln"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI-Verzögerungspuffer</string>
     <string name="forum">Aide (googlegroups)</string>
     <string name="songs">Songs</string>
+    <string name="location_not_enabled">Um eine Verbindung zu Geräten herzustellen, schalten Sie bitte „Standort“ ein. Wenn Sie einen Modus auswählen können, wählen Sie einen Modus, der Wi-Fi verwendet.</string>
+    <string name="location">Standort</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Σταματήστε την ανακάλυψη"</string>
     <string name="connections_failure">"Αποτυχία σύνδεσης"</string>
     <string name="connections_host">"Βρέθηκε κεντρικός υπολογιστής:"</string>
-    <string name="connections_log">"Αρχείο καταγραφής σύνδεσης (κάντε κλικ για διαγραφή). Εάν έχετε οποιαδήποτε προβλήματα, επαναφέρετε το WiFi σας και επανεκκινήστε την εφαρμογή."</string>
+    <string name="connections_log">Αρχείο καταγραφής σύνδεσης (κάντε κλικ για διαγραφή). Εάν έχετε οποιαδήποτε προβλήματα, επαναφέρετε το Wi-Fi σας και επανεκκινήστε την εφαρμογή.</string>
     <string name="connections_receive_host">"Λήψη τραγουδιών υποδοχής"</string>
     <string name="connections_searching">"Ερευνητικός…"</string>
     <string name="connections_service_start">"Ξεκινήστε την υπηρεσία"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Χρειάζεται καινούργια έκδοση Android για αυτό!"</string>
     <string name="notsaved">Δεν έχει αποθηκευτεί</string>
     <string name="notset">"Not set"</string>
-    <string name="nowifidirect">"Λυπούμαστε, αυτή η συσκευή δεν υποστηρίζει απευθείας WiFi"</string>
+    <string name="nowifidirect">Λυπούμαστε, αυτή η συσκευή δεν υποστηρίζει απευθείας Wi-Fi</string>
     <string name="off">"Off"</string>
     <string name="ok">"OK"</string>
     <string name="oldchordformat">"Detected current chord format"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Ενδιάμεση μνήμη καθυστέρησης MIDI</string>
     <string name="forum">Βοήθεια (googlegroups)</string>
     <string name="songs">Τραγούδια</string>
+    <string name="location_not_enabled">Για να συνδεθείτε σε συσκευές, ενεργοποιήστε την \"Τοποθεσία\". Εάν έχετε επιλογή λειτουργίας, επιλέξτε μια λειτουργία που χρησιμοποιεί Wi-Fi.</string>
+    <string name="location">Τοποθεσία</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Detener el descubrimiento"</string>
     <string name="connections_failure">"Error de conexión"</string>
     <string name="connections_host">"Se encontró host:"</string>
-    <string name="connections_log">"Registro de conexión (haga clic para borrar). Si tiene algún problema, restablezca su WiFi y reinicie la aplicación."</string>
+    <string name="connections_log">Registro de conexión (haga clic para borrar). Si tiene algún problema, restablezca su Wi-Fi y reinicie la aplicación.</string>
     <string name="connections_receive_host">"Recibir canciones de acogida"</string>
     <string name="connections_searching">"Buscando…"</string>
     <string name="connections_service_start">"Comienza el servicio"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Se necesita una versión más reciente de Android para esto!"</string>
     <string name="notsaved">No guardado</string>
     <string name="notset">"No establecido"</string>
-    <string name="nowifidirect">"Lo sentimos, este dispositivo no admite WiFi directo"</string>
+    <string name="nowifidirect">Lo sentimos, este dispositivo no admite Wi-Fi directo</string>
     <string name="off">"Apagado"</string>
     <string name="ok">"Aceptar"</string>
     <string name="oldchordformat">"Formato acorde actual Detectado"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Búfer de retardo MIDI</string>
     <string name="forum">Ayuda (googlegroups)</string>
     <string name="songs">Canciones</string>
+    <string name="location_not_enabled">Para conectarse a dispositivos, active \'Ubicación\'. Si tiene una opción de modo, elija un modo que use Wi-Fi.</string>
+    <string name="location">Ubicación</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Arrêtez la découverte"</string>
     <string name="connections_failure">"Échec de connexion"</string>
     <string name="connections_host">"Organisateur trouvé:"</string>
-    <string name="connections_log">"Journal de connexion (cliquez pour effacer). Si vous avez des problèmes, réinitialisez votre WiFi et redémarrez l'application."</string>
+    <string name="connections_log">Journal de connexion (cliquez pour effacer). Si vous avez des problèmes, réinitialisez votre Wi-Fi et redémarrez l\'application.</string>
     <string name="connections_receive_host">"Recevoir des chansons d'hôte"</string>
     <string name="connections_searching">"Recherche…"</string>
     <string name="connections_service_start">"Service de démarrage"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Vous avez besoin d\'une version plus récente d\'Android pour cela!"</string>
     <string name="notsaved">Non enregistré</string>
     <string name="notset">"A définir"</string>
-    <string name="nowifidirect">"Désolé, ce périphérique ne supporte pas WiFi Direct"</string>
+    <string name="nowifidirect">Désolé, ce périphérique ne supporte pas Wi-Fi Direct</string>
     <string name="off">"Non"</string>
     <string name="ok">"Valider"</string>
     <string name="oldchordformat">"Format d\'accords actuel détecté"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Tampon de retard MIDI</string>
     <string name="forum">Aide (googlegroups)</string>
     <string name="songs">Chansons</string>
+    <string name="location_not_enabled">Pour vous connecter à des appareils, veuillez activer la \"localisation\". Si vous avez le choix entre plusieurs modes, choisissez un mode qui utilise le Wi-Fi.</string>
+    <string name="location">Localisation</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"A stop felfedezés"</string>
     <string name="connections_failure">"Csatlakozási hiba"</string>
     <string name="connections_host">"Talált host:"</string>
-    <string name="connections_log">"Connection log (törölje). Ha bármilyen kérdés, állítsa vissza a WiFi, és indítsa újra az alkalmazást."</string>
+    <string name="connections_log">Connection log (törölje). Ha bármilyen kérdés, állítsa vissza a Wi-Fi, és indítsa újra az alkalmazást.</string>
     <string name="connections_receive_host">"Kap host dalok"</string>
     <string name="connections_searching">"Keresés …"</string>
     <string name="connections_service_start">"Kezdés szolgáltatás"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Szüksége van egy újabb változata Android for this!"</string>
     <string name="notsaved">Nem mentve</string>
     <string name="notset">"Nincs beállítva"</string>
-    <string name="nowifidirect">"Sajnos ez az eszköz nem támogatja a WiFi közvetlen"</string>
+    <string name="nowifidirect">Sajnos ez az eszköz nem támogatja a Wi-Fi közvetlen</string>
     <string name="off">"Ki"</string>
     <string name="ok">"Rendben"</string>
     <string name="oldchordformat">"Észlelt aktuális akkord formátumban"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI késleltetési puffer</string>
     <string name="forum">Segítség (googlegroups)</string>
     <string name="songs">Dalok</string>
+    <string name="location_not_enabled">Az eszközökhöz való csatlakozáshoz kapcsolja BE a „Tartózkodási hely” beállítást. Ha választhat módot, válasszon egy Wi-Fi-t használó módot.</string>
+    <string name="location">Tartózkodási hely</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Arresti la scoperta"</string>
     <string name="connections_failure">"Errore di connessione"</string>
     <string name="connections_host">"Ospite trovato:"</string>
-    <string name="connections_log">"Registro di connessione (fare clic per cancellare). Se hai problemi, ripristina il tuo WiFi e riavvia l'applicazione."</string>
+    <string name="connections_log">Registro di connessione (fare clic per cancellare). Se hai problemi, ripristina il tuo Wi-Fi e riavvia l\'applicazione.</string>
     <string name="connections_receive_host">"Ricevi canzoni host"</string>
     <string name="connections_searching">"Ricerca in corso …"</string>
     <string name="connections_service_start">"Avviare il servizio"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Hai bisogno di una versione più recente di Android per questo !"</string>
     <string name="notsaved">Non salvato</string>
     <string name="notset">"Non impostato"</string>
-    <string name="nowifidirect">"Spiacenti, questo dispositivo non supporta Direct WiFi"</string>
+    <string name="nowifidirect">Spiacenti, questo dispositivo non supporta Direct Wi-Fi</string>
     <string name="off">"Spento"</string>
     <string name="ok">"Bene"</string>
     <string name="oldchordformat">"Formato accordo corrente rilevato"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Buffer di ritardo MIDI</string>
     <string name="forum">Guida (googlegroups)</string>
     <string name="songs">Canzoni</string>
+    <string name="location_not_enabled">Per connetterti ai dispositivi, attiva \"Geolocalizzazione\". Se puoi scegliere la modalità, scegli una modalità che utilizza il Wi-Fi.</string>
+    <string name="location">Geolocalizzazione</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"発見を止める"</string>
     <string name="connections_failure">"接続障害"</string>
     <string name="connections_host">"見つかったホスト："</string>
-    <string name="connections_log">"接続ログ（クリックしてクリアする）。何か問題がある場合は、WiFiをリセットしてアプリを再起動してください。"</string>
+    <string name="connections_log">接続ログ（クリックしてクリアする）。何か問題がある場合は、Wi-Fiをリセットしてアプリを再起動してください。</string>
     <string name="connections_receive_host">"ホストソングを受信する"</string>
     <string name="connections_searching">"検索中…"</string>
     <string name="connections_service_start">"サービスを開始する"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"あなたはこのためのAndroidの新しいバージョンが必要です！"</string>
     <string name="notsaved">保存されません</string>
     <string name="notset">"設定されない"</string>
-    <string name="nowifidirect">"申し訳ありませんが、このデバイスはWiFiダイレクトをサポートしていません"</string>
+    <string name="nowifidirect">申し訳ありませんが、このデバイスはWi-Fiダイレクトをサポートしていません</string>
     <string name="off">"オフ"</string>
     <string name="ok">"オーケー (OK)"</string>
     <string name="oldchordformat">"検出された現在の和音フォーマット"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDIディレイバッファー</string>
     <string name="forum">ヘルプ (googlegroups)</string>
     <string name="songs">曲</string>
+    <string name="location_not_enabled">デバイスに接続するには、「位置情報」をオンにしてください。モードを選択できる場合は、Wi-Fi を使用するモードを選択します。</string>
+    <string name="location">位置情報</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Przestań odkrywać"</string>
     <string name="connections_failure">"Błąd połączenia"</string>
     <string name="connections_host">"Znaleziono hosta:"</string>
-    <string name="connections_log">"Dziennik połączeń (kliknij, aby wyczyścić). W razie jakichkolwiek problemów zresetuj WiFi i zrestartuj aplikację."</string>
+    <string name="connections_log">Dziennik połączeń (kliknij, aby wyczyścić). W razie jakichkolwiek problemów zresetuj Wi-Fi i zrestartuj aplikację.</string>
     <string name="connections_receive_host">"Odbieranie piosenek hostów"</string>
     <string name="connections_searching">"Badawczy…"</string>
     <string name="connections_service_start">"Uruchom usługę"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Wymagana jest nowsza wersja Androida dla tego !"</string>
     <string name="notsaved">Nie zapisane</string>
     <string name="notset">"Nie ustawiony"</string>
-    <string name="nowifidirect">"Przepraszamy, to urządzenie nie obsługuje WiFi bezpośrednio"</string>
+    <string name="nowifidirect">Przepraszamy, to urządzenie nie obsługuje Wi-Fi bezpośrednio</string>
     <string name="off">"Wył."</string>
     <string name="ok">"Działa prawidłowo "</string>
     <string name="oldchordformat">"Wykryto Format akord prądu"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Bufor opóźnienia MIDI</string>
     <string name="forum">Pomoc (googlegroups)</string>
     <string name="songs">Piosenki</string>
+    <string name="location_not_enabled">Aby połączyć się z urządzeniami, włącz „Lokalizacja”. Jeśli masz wybór trybu, wybierz tryb, który korzysta z Wi-Fi.</string>
+    <string name="location">Lokalizacja</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Você precisa de uma versão mais recente do Android para isso!"</string>
     <string name="notsaved">Não salvo</string>
     <string name="notset">"Não definido"</string>
-    <string name="nowifidirect">"Desculpe, este dispositivo não suporta WiFi direto"</string>
+    <string name="nowifidirect">Desculpe, este dispositivo não suporta Wi-Fi direto</string>
     <string name="off">"Fora"</string>
     <string name="ok">"OK"</string>
     <string name="oldchordformat">"Formato acorde atual Detectado"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Buffer de atraso MIDI</string>
     <string name="forum">Ajuda (googlegroups)</string>
     <string name="songs">Músicas</string>
+    <string name="location_not_enabled">Para se conectar a dispositivos, ative \'Localização\'. Se você tiver uma opção de modo, escolha um modo que use Wi-Fi.</string>
+    <string name="location">Localização</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Необходимо обновить версию Android!"</string>
     <string name="notsaved">Не сохранено</string>
     <string name="notset">"Не установлено"</string>
-    <string name="nowifidirect">"К сожалению, это устройство не поддерживает доступ к WiFi."</string>
+    <string name="nowifidirect">К сожалению, это устройство не поддерживает доступ к Wi-Fi.</string>
     <string name="off">"Выкл"</string>
     <string name="ok">"Ok"</string>
     <string name="oldchordformat">"Определен текущий формат аккордов"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Буфер задержки MIDI</string>
     <string name="forum">Помощь (googlegroups)</string>
     <string name="songs">Песни</string>
+    <string name="location_not_enabled">Чтобы подключиться к устройствам, включите «Местоположение». Если у вас есть выбор режима, выберите режим, использующий Wi-Fi.</string>
+    <string name="location">Местоположение</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -347,12 +347,12 @@
     <string name="my_church">"Uvoz primera crkvenih pesama"</string>
     <string name="navigate">"Brza navigacija"</string>
     <string name="new_category">"Nova kategorija"</string>
-    <string name="nowifidirect">"Izvinite, ovaj uređaj ne podržava WiFi direct"</string>
+    <string name="nowifidirect">Izvinite, ovaj uređaj ne podržava Wi-Fi direct</string>
     <string name="connections_connect">"Povezivanje uređaja"</string>
     <string name="connections_broadcast">"Uređaj za odašiljanje"</string>
     <string name="connections_connected">"Povezan sa"</string>
     <string name="connections_host">"Pronađen domaćin:"</string>
-    <string name="connections_log">"Log veze (kliknite da se očisti). Ako imate problema, resetujte WiFi i pokrenite ponovo program"</string>
+    <string name="connections_log">Log veze (kliknite da se očisti). Ako imate problema, resetujte Wi-Fi i pokrenite ponovo program</string>
     <string name="connections_disconnect">"Odvojite od"</string>
     <string name="connections_discover">"Pronalaženje servisa"</string>
     <string name="connections_discover_stop">"Zaustavljanje pronalaženja"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI bafer kašnjenja</string>
     <string name="forum">Pomoć (googlegroups)</string>
     <string name="songs">Песме</string>
+    <string name="location_not_enabled">Да бисте се повезали са уређајима, укључите „Локација“. Ако имате избор режима, изаберите режим који користи Ви-Фи.</string>
+    <string name="location">Локација</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"Sluta upptäckt"</string>
     <string name="connections_failure">"Anslutningsfel"</string>
     <string name="connections_host">"Hittade värd:"</string>
-    <string name="connections_log">"Anslutningslogg (klicka för att rensa). Om du har några problem, återställ WiFi och starta om appen."</string>
+    <string name="connections_log">Anslutningslogg (klicka för att rensa). Om du har några problem, återställ Wi-Fi och starta om appen.</string>
     <string name="connections_receive_host">"Ta emot värdlåt"</string>
     <string name="connections_searching">"Sökande…"</string>
     <string name="connections_service_start">"Starta service"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"Du behöver en nyare version av Android för detta!"</string>
     <string name="notsaved">Ej sparat</string>
     <string name="notset">"Inte inställd"</string>
-    <string name="nowifidirect">"Tyvärr, den här enheten stöder inte WiFi direkt"</string>
+    <string name="nowifidirect">Tyvärr, den här enheten stöder inte Wi-Fi direkt</string>
     <string name="off">"Av"</string>
     <string name="ok">"ok"</string>
     <string name="oldchordformat">"Upptäckt nuvarande ackordformat"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI fördröjningsbuffert</string>
     <string name="forum">Hjälp (googlegroups)</string>
     <string name="songs">Låtar</string>
+    <string name="location_not_enabled">Slå PÅ \'Plats\' för att ansluta till enheter. Om du har ett val av läge, välj ett läge som använder Wi-Fi.</string>
+    <string name="location">Plats</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">Необхідно оновити версію Android!</string>
     <string name="notsaved">Чи не збережено</string>
     <string name="notset">Не встановлено</string>
-    <string name="nowifidirect">На жаль, цей пристрій не підтримує доступ до WiFi.</string>
+    <string name="nowifidirect">На жаль, цей пристрій не підтримує доступ до Wi-Fi.</string>
     <string name="off">"Вимк"</string>
     <string name="ok">OK</string>
     <string name="oldchordformat">Визначено поточний формат акордів</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">Буфер затримки MIDI</string>
     <string name="forum">Допомога (googlegroups)</string>
     <string name="songs">Пісні</string>
+    <string name="location_not_enabled">Щоб підключитися до пристроїв, увімкніть «Місцезнаходження». Якщо у вас є вибір режиму, виберіть режим, який використовує Wi-Fi.</string>
+    <string name="location">Місцезнаходження</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -98,7 +98,7 @@
     <string name="connections_discover_stop">"停止发现"</string>
     <string name="connections_failure">"连接失败"</string>
     <string name="connections_host">"找到主机："</string>
-    <string name="connections_log">"连接日志（点击清除）。如果您有任何问题，请重置WiFi并重新启动应用程序。"</string>
+    <string name="connections_log">连接日志（点击清除）。如果您有任何问题，请重置Wi-Fi并重新启动应用程序。</string>
     <string name="connections_receive_host">"接收主播歌曲"</string>
     <string name="connections_searching">"搜索…"</string>
     <string name="connections_service_start">"开始服务"</string>
@@ -303,7 +303,7 @@
     <string name="nothighenoughapi">"你需要的Android这个较新版本！"</string>
     <string name="notsaved">没保存</string>
     <string name="notset">"未设置"</string>
-    <string name="nowifidirect">"对不起，此设备不支持WiFi直接"</string>
+    <string name="nowifidirect">对不起，此设备不支持Wi-Fi直接</string>
     <string name="off">"关闭"</string>
     <string name="ok">"确认"</string>
     <string name="oldchordformat">"检测当前的和弦格式"</string>
@@ -535,4 +535,6 @@
     <string name="midi_delay">MIDI 延迟缓冲器</string>
     <string name="forum">帮助 (googlegroups)</string>
     <string name="songs">歌曲</string>
+    <string name="location_not_enabled">要连接到设备，请打开“位置信息”。如果您可以选择模式，请选择使用 Wi-Fi 的模式。</string>
+    <string name="location">位置信息</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,7 +135,7 @@
     <string name="connections_discover_stop">Stop discovery</string>
     <string name="connections_failure">Connection failure</string>
     <string name="connections_host">Found host:</string>
-    <string name="connections_log">Connection log (click to clear).  If you have any issues, reset your WiFi and restart the app.</string>
+    <string name="connections_log">Connection log (click to clear).  If you have any issues, reset your Wi-Fi and restart the app.</string>
     <string name="connections_receive_host">Receive host songs</string>
     <string name="connections_searching">Searching…</string>
     <string name="connections_service_start">Start service</string>
@@ -410,7 +410,7 @@
     <string name="nothighenoughapi">You need a newer version of Android for this!</string>
     <string name="notsaved">not saved</string>
     <string name="notset">Not set</string>
-    <string name="nowifidirect">Sorry, this device does not support WiFi direct</string>
+    <string name="nowifidirect">Sorry, this device does not support Wi-Fi direct</string>
     <string name="off">Off</string>
     <string name="ok">OK</string>
     <string name="oldchordformat">Detected current chord format</string>
@@ -767,4 +767,6 @@
     <string name="nearby_large_file">This large song file is being shared</string>
     <string name="midi_delay">Midi delay buffer</string>
     <string name="songs">Songs</string>
+    <string name="location_not_enabled">To connect to devices please turn \'Location\' ON.  If you have a choice of mode, choose a mode that uses Wi-Fi.</string>
+    <string name="location">Location</string>
 </resources>


### PR DESCRIPTION
Hi Gareth,

Another pain point for me...

One of my music friends uses OpenSongApp on a Fire 10 HD and seems somehow to keep turning Location Services off!  This stops their use of 'Act as Client' from ever connecting when we are sharing songs.  Fixing involves painful searching for the Location options in strange settings options!

This commit tries to test for Device Location Services being ON and if not have the user correct before using Connect Devices, opening the Location settings for the user to adjust.    Works for me on Android 12, 8, 5.  Found the approach on the Internet and used a similar dialog style to other 'Connect devices' dialogs.

Please consider.

Kind regards
Ian