### PR TITLE
Nearby permission - manual adjust backstop

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -34,7 +34,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.UUID;
 
 public class NearbyConnections implements NearbyInterface {
 
@@ -198,21 +197,10 @@ public class NearbyConnections implements NearbyInterface {
     }
 
     public String getUserNickname() {
-        try {
-            if (StaticVariables.deviceName == null || StaticVariables.deviceName.isEmpty() ||
-                    (FullscreenActivity.mBluetoothName != null && FullscreenActivity.mBluetoothName.equals(StaticVariables.deviceName))) {
-                if (FullscreenActivity.mBluetoothName == null || FullscreenActivity.mBluetoothName.equals("Unknown")) {
-                    FullscreenActivity.mBluetoothName = UUID.randomUUID().toString().substring(0, 8);
-                    FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothName.toUpperCase(StaticVariables.locale);
-                }
-                StaticVariables.deviceName = preferences.getMyPreferenceString(context, "deviceId", "");
-                // IV - If the user has not set an override name use the Bluetooth name
-                if (StaticVariables.deviceName.isEmpty()) {
-                    StaticVariables.deviceName = FullscreenActivity.mBluetoothName;
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+        StaticVariables.deviceName = preferences.getMyPreferenceString(context, "deviceId", "");
+        // IV - If the user has not set a device name use mBluetoothName
+        if (StaticVariables.deviceName.isEmpty()) {
+            StaticVariables.deviceName = FullscreenActivity.mBluetoothName;
         }
         return StaticVariables.deviceName;
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/NearbyConnections.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.UUID;
 
 public class NearbyConnections implements NearbyInterface {
 
@@ -197,10 +198,21 @@ public class NearbyConnections implements NearbyInterface {
     }
 
     public String getUserNickname() {
-        StaticVariables.deviceName = preferences.getMyPreferenceString(context, "deviceId", "");
-        // IV - If the user has not set a device name use mBluetoothName
-        if (StaticVariables.deviceName.isEmpty()) {
-            StaticVariables.deviceName = FullscreenActivity.mBluetoothName;
+        try {
+            // IV - If deviceName is null, determine the current deviceName.
+            if (StaticVariables.deviceName == null) {
+                // IV - If user has set a device id then use, otherwise use Bluetooth name. If no Bluetooth name (should never happen), use a random name.
+                StaticVariables.deviceName = preferences.getMyPreferenceString(context, "deviceId", "");
+                if (StaticVariables.deviceName.isEmpty()) {
+                    if (FullscreenActivity.mBluetoothName != null) {
+                        StaticVariables.deviceName = FullscreenActivity.mBluetoothName;
+                    } else {
+                        StaticVariables.deviceName = UUID.randomUUID().toString().substring(0, 8).toUpperCase(StaticVariables.locale);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
         return StaticVariables.deviceName;
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -28,6 +28,8 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
+import java.util.Objects;
+
 public class OptionMenuListeners extends AppCompatActivity implements MenuInterface{
 
     @SuppressLint("StaticFieldLeak")
@@ -595,7 +597,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                     if (mListener!=null) {
                         if (!mListener.hasNearbyPermissions()) {
                             // IV - requestNearbyPermissions has run, as "■" is set, but permissions are not right. We ask the user to set permissions in Apps management.
-                            if (FullscreenActivity.mBluetoothName == "■") {
+                            if (Objects.equals(FullscreenActivity.mBluetoothName, "■")) {
                                 AlertDialog.Builder dialog = new AlertDialog.Builder(c)
                                         .setTitle(R.string.connections_connect)
                                         .setIcon(android.R.drawable.ic_dialog_alert)
@@ -611,7 +613,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                             // IV - We force a getBluetoothName
                             FullscreenActivity.mBluetoothName = "■";
                         } else {
-                            if (FullscreenActivity.mBluetoothName == "■") {
+                            if (Objects.equals(FullscreenActivity.mBluetoothName, "■")) {
                                 mListener.getBluetoothName();
                             }
                             StaticVariables.whichOptionMenu = "CONNECT";

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -587,18 +587,31 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                             .setTitle(R.string.location)
                             .setIcon(android.R.drawable.ic_dialog_alert)
                             .setMessage(c.getString(R.string.location_not_enabled))
-                            .setPositiveButton(c.getString(R.string.location), (paramDialogInterface, paramInt) -> c.startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)))
+                            .setPositiveButton(c.getString(R.string.next), (paramDialogInterface, paramInt) -> c.startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)))
                             .setNegativeButton(c.getString(R.string.cancel), null);
                     dialog.create();
                     dialog.show();
                 } else {
                     if (mListener!=null) {
                         if (!mListener.hasNearbyPermissions()) {
-                            mListener.requestNearbyPermissions();
-                            // IV - We force a getBluetoothName next time through
-                            FullscreenActivity.mBluetoothName = null;
+                            // IV - requestNearbyPermissions has run, as "■" is set, but permissions are not right. We ask the user to set permissions in Apps management.
+                            if (FullscreenActivity.mBluetoothName == "■") {
+                                AlertDialog.Builder dialog = new AlertDialog.Builder(c)
+                                        .setTitle(R.string.connections_connect)
+                                        .setIcon(android.R.drawable.ic_dialog_alert)
+                                        .setMessage(c.getString(R.string.connections_enable))
+                                        .setPositiveButton(c.getString(R.string.next), (paramDialogInterface, paramInt) -> c.startActivity(new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,Uri.parse("package:" + c.getPackageName()))))
+                                        .setNegativeButton(c.getString(R.string.cancel), null);
+                                dialog.create();
+                                dialog.show();
+                                mListener.closeMyDrawers("option");
+                            } else {
+                                mListener.requestNearbyPermissions();
+                            }
+                            // IV - We force a getBluetoothName
+                            FullscreenActivity.mBluetoothName = "■";
                         } else {
-                            if (FullscreenActivity.mBluetoothName == null) {
+                            if (FullscreenActivity.mBluetoothName == "■") {
                                 mListener.getBluetoothName();
                             }
                             StaticVariables.whichOptionMenu = "CONNECT";

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -60,7 +60,6 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         void openFragment();
         void openMyDrawers(String which);
         void closeMyDrawers(String which);
-        void getBluetoothName();
         void refreshActionBar();
         void loadSong();
         void prepareSongMenu();
@@ -84,6 +83,8 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         boolean requestNearbyPermissions();
         boolean hasNearbyPermissions();
         void installPlayServices();
+        void getBluetoothName();
+        String getUserNickname();
     }
 
     private static MyInterface mListener;
@@ -610,11 +611,13 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                             } else {
                                 mListener.requestNearbyPermissions();
                             }
-                            // IV - We force a getBluetoothName
                             FullscreenActivity.mBluetoothName = "■";
+                            StaticVariables.deviceName = null;
                         } else {
-                            if (Objects.equals(FullscreenActivity.mBluetoothName, "■")) {
+                            // IV - deviceName is null the first time through or after requesting permissions.
+                            if (StaticVariables.deviceName == null) {
                                 mListener.getBluetoothName();
+                                mListener.getUserNickname();
                             }
                             StaticVariables.whichOptionMenu = "CONNECT";
                             mListener.prepareOptionMenu();
@@ -1812,9 +1815,6 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         LinearLayout hostOptions = v.findViewById(R.id.hostOptions);
         LinearLayout clientOptions = v.findViewById(R.id.clientOptions);
 
-        nearbyInterface.getUserNickname();
-
-        deviceName.setText(StaticVariables.deviceName);
         if (StaticVariables.connectionLog==null || StaticVariables.connectionLog.isEmpty()) {
             StaticVariables.connectionLog = c.getResources().getString(R.string.connections_log) + "\n\n";
         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/OptionMenuListeners.java
@@ -58,6 +58,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
         void openFragment();
         void openMyDrawers(String which);
         void closeMyDrawers(String which);
+        void getBluetoothName();
         void refreshActionBar();
         void loadSong();
         void prepareSongMenu();
@@ -402,9 +403,7 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                 break;
 
             case "CONNECT":
-                if (mListener!=null && mListener.requestNearbyPermissions()) {
-                    connectOptionListener(v, c, preferences);
-                }
+                connectOptionListener(v, c, preferences);
                 break;
 
             case "MIDI":
@@ -593,17 +592,24 @@ public class OptionMenuListeners extends AppCompatActivity implements MenuInterf
                     dialog.create();
                     dialog.show();
                 } else {
-                    if (mListener!=null && mListener.hasNearbyPermissions()) {
-                        StaticVariables.whichOptionMenu = "CONNECT";
-                        mListener.prepareOptionMenu();
-                    } else {
-                        if (mListener != null) {
+                    if (mListener!=null) {
+                        if (!mListener.hasNearbyPermissions()) {
                             mListener.requestNearbyPermissions();
+                            // IV - We force a getBluetoothName next time through
+                            FullscreenActivity.mBluetoothName = null;
+                        } else {
+                            if (FullscreenActivity.mBluetoothName == null) {
+                                mListener.getBluetoothName();
+                            }
+                            StaticVariables.whichOptionMenu = "CONNECT";
+                            mListener.prepareOptionMenu();
                         }
                     }
                 }
             } else {
-                mListener.installPlayServices();
+                if (mListener!=null) {
+                    mListener.installPlayServices();
+                }
             }
         });
         menuModeButton.setOnClickListener(view -> {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpConnectFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpConnectFragment.java
@@ -27,6 +27,7 @@ public class PopUpConnectFragment extends DialogFragment {
 
     public interface MyInterface {
         void prepareOptionMenu();
+        String getUserNickname();
     }
 
     private static MyInterface mListener;
@@ -37,7 +38,7 @@ public class PopUpConnectFragment extends DialogFragment {
         super.onAttach(context);
     }
 
-    private TextView title, deviceNameTextView;
+    private TextView title;
     private EditText deviceNameEditText;
     private FloatingActionButton saveMe;
     private Preferences preferences;
@@ -72,16 +73,14 @@ public class PopUpConnectFragment extends DialogFragment {
 
         // Initialise the views
         deviceNameEditText = V.findViewById(R.id.deviceNameEditText);
-        // IV - Changed to DeviceId which is the pref used by getUserNickname()
-        deviceNameEditText.setText(preferences.getMyPreferenceString(getContext(), "deviceId", ""));
+        // IV - Start with the broadcasting device name
+        deviceNameEditText.setText(mListener.getUserNickname());
 
         // Set up save/tick listener
         saveMe.setOnClickListener(view -> {
+            // IV - Allows an empty string which will clear this 'override' preference
             String s = deviceNameEditText.getText().toString().trim();
-            if (s.length() > 0) {
-                preferences.setMyPreferenceString(getContext(), "deviceId", s);
-                StaticVariables.deviceName = s;
-            }
+            preferences.setMyPreferenceString(getContext(), "deviceId", s);
             doSave();
         });
         Dialog dialog = getDialog();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpConnectFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpConnectFragment.java
@@ -73,14 +73,17 @@ public class PopUpConnectFragment extends DialogFragment {
 
         // Initialise the views
         deviceNameEditText = V.findViewById(R.id.deviceNameEditText);
-        // IV - Start with the broadcasting device name
+        // IV - Start with the current name
         deviceNameEditText.setText(mListener.getUserNickname());
 
         // Set up save/tick listener
         saveMe.setOnClickListener(view -> {
-            // IV - Allows an empty string which will clear this 'override' preference
+            // IV - An empty string will clear this 'override' preference
             String s = deviceNameEditText.getText().toString().trim();
             preferences.setMyPreferenceString(getContext(), "deviceId", s);
+            // IV - Set null to have getUserNickname update deviceName
+            StaticVariables.deviceName = null;
+            mListener.getUserNickname();
             doSave();
         });
         Dialog dialog = getDialog();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -88,6 +88,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import lib.folderpicker.FolderPicker;
 
@@ -415,8 +416,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             // Set up the Nearby connection service
             permissions = new Permissions();
             permissions.setNearbyPermissionsString();
-            getBluetoothName();
-            nearbyConnections.getUserNickname();
 
             // Initialise the ab info
             adjustABInfo();
@@ -1891,33 +1890,28 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
         }
     }
 
-    private void getBluetoothName() {
+    public void getBluetoothName() {
+        FullscreenActivity.mBluetoothName = null;
         // Only do this if we have the correct permissions
         if (permissions.hasNearbyPermissions(this)) {
             try {
+                if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT))) {
+                    permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
+                }
                 if (FullscreenActivity.mBluetoothAdapter == null) {
                     FullscreenActivity.mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
                 }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    if (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT)) {
-                        permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
-                        return;
-                    } else {
-                        FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
-                    }
-
-                } else {
-                    FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
-                }
-                if (FullscreenActivity.mBluetoothName == null) {
-                    FullscreenActivity.mBluetoothName = "Unknown";
-                }
+                FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
             } catch (Exception e) {
-                FullscreenActivity.mBluetoothName = "Unknown";
+                e.printStackTrace();
             }
         }
+        // IV - If we could not get the Bluetooth name, use a random name
+        if (FullscreenActivity.mBluetoothName == null) {
+            FullscreenActivity.mBluetoothName = UUID.randomUUID().toString().substring(0, 8);
+            FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothName.toUpperCase(StaticVariables.locale);
+        }
     }
-
 
     // Loading the song
     @Override

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -88,7 +88,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import lib.folderpicker.FolderPicker;
 
@@ -413,9 +412,10 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
 
             // IV - refreshAll call later will perform setupButtons, prepareOptionsMenu and setupSongButtons
 
-            // Set up the Nearby connection service
+            // Initialise the Nearby connection service
             permissions = new Permissions();
             permissions.setNearbyPermissionsString();
+            StaticVariables.deviceName = null;
 
             // Initialise the ab info
             adjustABInfo();
@@ -1891,6 +1891,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
     }
 
     public void getBluetoothName() {
+        // IV - We return the Bluetooth name or null to indicate unavailable.
         FullscreenActivity.mBluetoothName = null;
         // Only do this if we have the correct permissions
         if (permissions.hasNearbyPermissions(this)) {
@@ -1905,11 +1906,6 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        }
-        // IV - If we could not get the Bluetooth name, use a random name
-        if (FullscreenActivity.mBluetoothName == null) {
-            FullscreenActivity.mBluetoothName = UUID.randomUUID().toString().substring(0, 8);
-            FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothName.toUpperCase(StaticVariables.locale);
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PresenterMode.java
@@ -1898,6 +1898,7 @@ public class PresenterMode extends AppCompatActivity implements MenuHandlers.MyI
             try {
                 if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT))) {
                     permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
+                    return;
                 }
                 if (FullscreenActivity.mBluetoothAdapter == null) {
                     FullscreenActivity.mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -102,7 +102,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import lib.folderpicker.FolderPicker;
 
@@ -571,9 +570,10 @@ public class StageMode extends AppCompatActivity implements
                 closeMyDrawers("song");
             });
 
-            // Set up the Nearby connection service
+            // Initialise the Nearby connection service
             permissions = new Permissions();
             permissions.setNearbyPermissionsString();
+            StaticVariables.deviceName = null;
 
             dealWithIntent();
 
@@ -881,6 +881,7 @@ public class StageMode extends AppCompatActivity implements
     }
 
     public void getBluetoothName() {
+        // IV - We return the Bluetooth name or null to indicate unavailable.
         FullscreenActivity.mBluetoothName = null;
         // Only do this if we have the correct permissions
         if (permissions.hasNearbyPermissions(this)) {
@@ -895,11 +896,6 @@ public class StageMode extends AppCompatActivity implements
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        }
-        // IV - If we could not get the Bluetooth name, use a random name
-        if (FullscreenActivity.mBluetoothName == null) {
-            FullscreenActivity.mBluetoothName = UUID.randomUUID().toString().substring(0, 8);
-            FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothName.toUpperCase(StaticVariables.locale);
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -102,6 +102,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import lib.folderpicker.FolderPicker;
 
@@ -573,8 +574,6 @@ public class StageMode extends AppCompatActivity implements
             // Set up the Nearby connection service
             permissions = new Permissions();
             permissions.setNearbyPermissionsString();
-            getBluetoothName();
-            nearbyConnections.getUserNickname();
 
             dealWithIntent();
 
@@ -881,30 +880,26 @@ public class StageMode extends AppCompatActivity implements
         });
     }
 
-    private void getBluetoothName() {
+    public void getBluetoothName() {
+        FullscreenActivity.mBluetoothName = null;
         // Only do this if we have the correct permissions
         if (permissions.hasNearbyPermissions(this)) {
             try {
+                if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT))) {
+                    permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
+                }
                 if (FullscreenActivity.mBluetoothAdapter == null) {
                     FullscreenActivity.mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
                 }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    if (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT)) {
-                        permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
-                        return;
-                    } else {
-                        FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
-                    }
-
-                } else {
-                    FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
-                }
-                if (FullscreenActivity.mBluetoothName == null) {
-                    FullscreenActivity.mBluetoothName = "Unknown";
-                }
+                FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothAdapter.getName();
             } catch (Exception e) {
-                FullscreenActivity.mBluetoothName = "Unknown";
+                e.printStackTrace();
             }
+        }
+        // IV - If we could not get the Bluetooth name, use a random name
+        if (FullscreenActivity.mBluetoothName == null) {
+            FullscreenActivity.mBluetoothName = UUID.randomUUID().toString().substring(0, 8);
+            FullscreenActivity.mBluetoothName = FullscreenActivity.mBluetoothName.toUpperCase(StaticVariables.locale);
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StageMode.java
@@ -888,6 +888,7 @@ public class StageMode extends AppCompatActivity implements
             try {
                 if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && (!permissions.checkForPermission(this,Manifest.permission.BLUETOOTH_CONNECT))) {
                     permissions.requestForPermissions(this, new String[]{Manifest.permission.BLUETOOTH_CONNECT}, 488);
+                    return;
                 }
                 if (FullscreenActivity.mBluetoothAdapter == null) {
                     FullscreenActivity.mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="connections_service_start">Start service</string>
     <string name="connections_service_stop">Stop service</string>
     <string name="connections_success">Connection success</string>
-    <string name="connections_enable">Enable nearby connections</string>
+    <string name="connections_enable">Please change this App\'s permissions to allow access to precise \'Location\' and, if listed, \'Nearby devices\'.</string>
     <string name="connections_actashost">Act as host</string>
     <string name="connections_keephostsongs">Keep host songs</string>
     <string name="content">Content</string>


### PR DESCRIPTION
Hello Gareth,

When testing, I spotted that when a user has, in some way, opted to not allow permissions, 'Connect devices' will not open and no prompt is made to allow permission - the user needs to manually adjusting permissions to fix this.  I have added a prompt to manually adjust permissions that takes the user to OpenSongApp 'App info' and simplified some code.  Hopefully good across Android versions!

Also, I have tried to improve Nearby 'Broadcast name' - the 'random' name is no longer seen the first time 'Connect devices' is used after a prompt for permissions.

Please consider.

Kind regards
Ian

