### PR TITLE
fix folder import

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExportOSBFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/PopUpImportExportOSBFragment.java
@@ -394,7 +394,7 @@ public class PopUpImportExportOSBFragment extends DialogFragment {
                     for (String aFoldersselectedtoimport : foldersselectedtoimport) {
                         // Is it in the main folder
                         if ((aFoldersselectedtoimport.equals(getString(R.string.mainfoldername) + "/") ||
-                                (aFoldersselectedtoimport.equals("MAIN" + "/"))) && !ze.getName().contains("/")) {
+                                (aFoldersselectedtoimport.equals("MAIN/")))) {
                             oktoimportthisone = true;
                             // Or another folder
                         } else if (ze.getName().contains(aFoldersselectedtoimport)) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StorageAccess.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StorageAccess.java
@@ -891,9 +891,6 @@ class StorageAccess {
                     String bit = "";
                     for (String s : bits) {
                         parentUri = getUriForItem(c, preferences, folder, bit, "");
-                        String songsFolder = stringForFile(c,preferences,"Songs");
-                        Uri newUri = parentUri.buildUpon().appendPath(s).build();
-                        File exists = new File(newUri.getPath());
                         if (mimeType == null && uriExists(c, parentUri)) {
                             docContractCreate(c, parentUri, DocumentsContract.Document.MIME_TYPE_DIR, s);
                         }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/StorageAccess.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/StorageAccess.java
@@ -835,7 +835,11 @@ class StorageAccess {
                     String bit = "";
                     for (String s : bits) {
                         parentUri = getUriForItem(c, preferences, folder, bit, "");
-                        docContractCreate(c, parentUri, mimeType, s);
+                        Uri newUri = parentUri;
+                        newUri.buildUpon().appendPath(s);
+                        if (!uriExists(c, newUri)) {
+                            docContractCreate(c, parentUri, mimeType, s);
+                        }
                         bit = bit + "/" + s;
                     }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048M
 -Dorg.gradle.warning.mode=all
+org.gradle.unsafe.configuration-cache=true
+


### PR DESCRIPTION
Using an old backup, I tried to import my songs, and was faced with spurious directory creation, at various points in the directory tree (under Songs), that were empty.   So, I hacked the code and added some existence tests, and the directory tree structure and files are all created correctly, as far as I can tell, with the exception of two top level copies of the final top level directory.
This doesn't seem to occur with a newly created folder system, backed up and reimported, but I haven't created a particularly large tree to test.
I haven't got the time currently, to devote to refactoring the code, but there are various optimizations that could be made.