### PR TITLE
Fix: ProcessSongIntoSections - double new line split handling

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/MainActivity.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/MainActivity.java
@@ -947,7 +947,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityInter
             // IV - We are changing so adjust option menu elements
             if (globalMenuItem != null) {
                 // IV - To smooth teardown, we clear elements left to right
-                if (!settingsOpen && whichMode.equals(performance)) {
+                if (settingsOpen && !whichMode.equals(presenter)) {
                     myView.myToolbar.hideSongDetails(true);
                 }
                 myView.myToolbar.batteryholderVisibility(false, false);
@@ -3106,7 +3106,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityInter
                 performanceShowSection(i);
             }
         } else {
-            nearbyConnections.setPendingCurrentSection(i);
+            nearbyConnections.setPendingSection(i);
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/metronome/Metronome.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/metronome/Metronome.java
@@ -183,40 +183,44 @@ public class Metronome {
     }
     public void setSongValues() {
         // First up the tempo
+        int tempo = 0;
         validTempo = false;
         String t = mainActivityInterface.getSong().getTempo();
-        // Check for text version from desktop app
-        t = t.replace("Very Fast", "140").
-                replace("Fast", "120").
-                replace("Moderate", "100").
-                replace("Slow", "80").
-                replace("Very Slow", "60").
-                replaceAll("[\\D]", "");
-        int tempo;
         try {
-            tempo = (short) Integer.parseInt(t);
-            validTempo = true;
-        } catch (NumberFormatException nfe) {
-            tempo = 0;
-        }
+            // Check for text version from desktop app
+            t = t.replace("Very Fast", "140").
+                    replace("Fast", "120").
+                    replace("Moderate", "100").
+                    replace("Slow", "80").
+                    replace("Very Slow", "60").
+                    replaceAll("[\\D]", "");
+            try {
+                tempo = (short) Integer.parseInt(t);
+                validTempo = true;
+            } catch (NumberFormatException nfe) {
+                tempo = 0;
+            }
 
-        // Check the tempo is within the permitted range
-        if (tempo <40 || tempo >299) {
-            tempo = 0;
-            validTempo = false;
-        }
+            // Check the tempo is within the permitted range
+            if (tempo <40 || tempo >299) {
+                tempo = 0;
+                validTempo = false;
+            }
 
-        // This bit splits the time signature into beats and divisions
-        // We then deal with compound time signatures and get a division factor
-        // Compound and complex time signatures can have additional emphasis beats (not just beat 1)
-        processTimeSignature();
-        meterTimeFactor(); // 1.0f for simple signatures, 2.0f or 3.0f for compound ones
-        getEmphasisBeats();   // Always has beat 1, but can have more
+            // This bit splits the time signature into beats and divisions
+            // We then deal with compound time signatures and get a division factor
+            // Compound and complex time signatures can have additional emphasis beats (not just beat 1)
+            processTimeSignature();
+            meterTimeFactor(); // 1.0f for simple signatures, 2.0f or 3.0f for compound ones
+            getEmphasisBeats();   // Always has beat 1, but can have more
 
-        if (tempo >0) {
-            beatTimeLength = Math.round(((60.0f / (float) tempo) * 1000.0f) / meterTimeDivision);
-        } else {
-            beatTimeLength = 0;
+            if (tempo >0) {
+                beatTimeLength = Math.round(((60.0f / (float) tempo) * 1000.0f) / meterTimeDivision);
+            } else {
+                beatTimeLength = 0;
+            }
+        } catch (Exception e) {
+            // Badly formatted tempo
         }
     }
     public ArrayList<String> processTimeSignature() {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/presenter/SongSectionsAdapter.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/presenter/SongSectionsAdapter.java
@@ -118,7 +118,7 @@ public class SongSectionsAdapter extends RecyclerView.Adapter<SongSectionViewHol
             }
             newContent.append(line).append("\n");
         }
-        return newContent.toString();
+        return newContent.toString().trim();
     }
 
     @NonNull
@@ -265,6 +265,16 @@ public class SongSectionsAdapter extends RecyclerView.Adapter<SongSectionViewHol
         // State we've started projection
         // This method checks that logo, black screen, blank screen are off too
         mainActivityInterface.getPresenterSettings().setStartedProjection(true);
+        if (mainActivityInterface.getSong().getFiletype().equals("PDF")) {
+            mainActivityInterface.getSong().setPdfPageCurrent(thisPos);
+        } else {
+            mainActivityInterface.getSong().setCurrentSection(thisPos);
+        }
+        // IV - Send the section change to Nearby clients
+        if (mainActivityInterface.getNearbyConnections().hasValidConnections() &&
+                mainActivityInterface.getNearbyConnections().getIsHost()) {
+            mainActivityInterface.getNearbyConnections().sendSongSectionPayload();
+        }
     }
 
     public void setSectionEditedContent(String content) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/presenter/SongSectionsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/presenter/SongSectionsFragment.java
@@ -117,7 +117,15 @@ public class SongSectionsFragment extends Fragment {
                     mainActivityInterface.getSong() != null) {
                 myView.songInfo.setSongTitle(mainActivityInterface.getSong().getTitle());
                 myView.songInfo.setSongAuthor(mainActivityInterface.getSong().getAuthor());
-                myView.songInfo.setSongCopyright("©" + mainActivityInterface.getSong().getCopyright());
+                String copyright = mainActivityInterface.getSong().getCopyright();
+                if (copyright != null && !copyright.isEmpty()) {
+                    if (!copyright.contains("©")) {
+                        copyright = "©" + copyright;
+                    }
+                } else {
+                    copyright = "";
+                }
+                myView.songInfo.setSongCopyright(copyright);
                 myView.songInfo.setSongCCLI(mainActivityInterface.getSong().getCcli());
                 myView.imageSlideInfo.setVisibility(View.GONE);
                 myView.imageSlideLoop.setVisibility(View.GONE);
@@ -201,6 +209,7 @@ public class SongSectionsFragment extends Fragment {
             mainActivityInterface.getPresenterSettings().getSongSectionsAdapter().setSelectedPosition(newPosition);
             mainActivityInterface.getPresenterSettings().getSongSectionsAdapter().notifyItemChanged(oldPosition, "colorchange");
             mainActivityInterface.getPresenterSettings().getSongSectionsAdapter().notifyItemChanged(newPosition, "colorchange");
+            mainActivityInterface.getPresenterSettings().getSongSectionsAdapter().itemSelected(newPosition);
         }
     }
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
@@ -620,8 +620,12 @@ public class SecondaryDisplay extends Presentation {
                         getPresenterSettings().getCcliLicence();
             }
             String copyright = mainActivityInterface.getSong().getCopyright();
-            if (copyright != null && !copyright.isEmpty() && !copyright.contains("©")) {
-                copyright = "©" + copyright;
+            if (copyright != null && !copyright.isEmpty()) {
+                if (!copyright.contains("©")) {
+                    copyright = "©" + copyright;
+                }
+            } else {
+                copyright = "";
             }
             String author = mainActivityInterface.getSong().getAuthor();
             if (author != null && !author.isEmpty()) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
@@ -1527,11 +1527,17 @@ public class ProcessSong {
                 .replace("\n [", "\n§[")
                 .replace("\n[", "\n§[")
                 .replace("\n\n", doubleNewlineSplit)
-                .replace("§§","§")
-                // --- Remove the leading added leading \n
+                .replaceAll("§+","§")
+                // --- Remove the added leading \n
                 .substring(1)
-                // --- Because we trail with ¶, this removes the added leading \n as part of removing leading white space                // --- Now remove trailing ¶
+                // --- Remove the added trailing ¶
                 .replace("¶","");
+
+        // IV - Compress runs of empty sections created by doubleNewLineSplit into one
+        if (doubleNewlineSplit.equals("§")) {
+            lyrics = lyrics.replaceAll("§\\s+§","§")
+                    .replaceAll("§+","§");
+        }
 
         // 9. Handle || splits
         String[] sections = lyrics.split("§");

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
@@ -831,9 +831,9 @@ public class ProcessSong {
 
     // Keep only wanted lines and group lines that should be in a table for alignment purposes
     public String filterAndGroupLines(String string, boolean displayChords) {
-        // IV - If no content then return an empty section
+        // IV - If no content then return an empty string
         if (string == null || string.trim().isEmpty()) {
-            return "\n§[]";
+            return "";
         }
 
         StringBuilder sb = new StringBuilder();
@@ -874,10 +874,7 @@ public class ProcessSong {
             }
         }
         String fixed = sb.toString();
-        // IV - Correct any leading section break
-        if (fixed.startsWith("\n§")) {
-            fixed = "\n" + fixed;
-        }
+
         // IV - Lines are added with leading \n, the first needs to be removed.  We restore section breaks.
         return fixed.replaceFirst("\n","");
     }
@@ -1620,10 +1617,6 @@ public class ProcessSong {
                     // Remove whitespace before the section marker
                     .replaceAll("\\s+§","\n\n§");
         }
-        // IV - Fix a trimmed leading section marker
-        if (lyrics.startsWith("§")) {
-            lyrics = "\n\n" + lyrics;
-        }
 
         // 12. Go through the lyrics and get section headers and add to the song object
         song.setSongSectionHeadings(getSectionHeadings(lyrics));
@@ -1639,6 +1632,16 @@ public class ProcessSong {
         // 14. Build the songSections for later recall
         // The song sections are not the views (which can have sections repeated using presentationOrder)
         // The grouped sections are used for alignments
+
+        // IV - Handle empty lyrics and fix a trimmed leading section marker
+        if (lyrics.equals("")) {
+            lyrics = "\n\n§[]";
+        } else if (lyrics.startsWith("§")) {
+            lyrics = "\n\n" + lyrics;
+        } else if (lyrics.startsWith("\n§")) {
+            lyrics = "\n" + lyrics;
+        }
+
         songSections = new ArrayList<>();
         ArrayList<String> groupedSections = new ArrayList<>();
 


### PR DESCRIPTION
Hello Gareth,

This avoids lots of empty sections when double new line split processes a run of empty lines .  The code reflects a view that runs start a section (/n/n) that begins with blank lines (more /n).

So

/n/n/n/n/n/n Lyric/n

is processed as '[]/n/n/n/n Lyric/n' which after trim is '[]/n  Lyric/n' - 1 section.

and not process each /n/n as a section which would make it

'[]/n[]/n[]/n Lyric/n' which after trim is  unchanged as '[]/n[]/n[]/n Lyric/n' - 3 sections.

I believe this is better.


