### PR TITLE
Enh: v6 catch up with v5 SongSelect import.  Fix: Transpose preferred keys.

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/chords/Transpose.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/chords/Transpose.java
@@ -191,10 +191,6 @@ public class Transpose {
     private int major;
     private int root;
 
-    private boolean forceFlats;
-    private boolean usesFlats;
-    private boolean capoForceFlats;
-    private boolean capoUsesFlats;
     private String capoKey;
     private int oldChordFormat, newChordFormat;
     private String transposeDirection;
@@ -257,7 +253,9 @@ public class Transpose {
         tempSong.setDesiredChordFormat(1);
         transposeDirection = "-1";
         transposeTimes = capo;
-        return transposeString(tempSong).replace(".","");
+
+        // IV - Number converts are used to return the users preferred key
+        return numberToKey(keyToNumber(transposeString(tempSong).replace(".","")));
     }
 
     public String keyToNumber(String key) {
@@ -327,6 +325,7 @@ public class Transpose {
         miniTransposeSong.setDesiredChordFormat(mainActivityInterface.getSong().getDesiredChordFormat());
         transposeTimes = capo;
         transposeDirection = "-1";
+        miniTransposeSong.setKey(capoKey);
         return transposeString(miniTransposeSong);
     }
 
@@ -334,13 +333,7 @@ public class Transpose {
     public String transposeString(Song thisSong) {
 
         // Now we have the new key, we can decide if we use flats or not for any notes
-        if (thisSong.getKey()!=null) {
-            forceFlats = keyUsesFlats(thisSong.getKey());
-            usesFlats = forceFlats;
-        } else {
-            usesFlats = forceFlats;
-            forceFlats = false;
-        }
+        boolean forceFlats = thisSong.getKey() != null && keyUsesFlats(thisSong.getKey());
 
         try {
             StringBuilder sb = new StringBuilder();
@@ -723,31 +716,10 @@ public class Transpose {
         }
     }
 
-    String capoTranspose() {
-        // StageMode sets FullscreenActivity.capokey to "" in loadSong(), first call after sets for new song
-        if (capoKey.equals("")) {
-            // Get the capokey
-            if (mainActivityInterface.getSong().getKey() != null) {
-                capoKeyTranspose();
-            }
-            // Determine if we need to force flats for the capo key
-            capoForceFlats = keyUsesFlats(capoKey);
-        }
-
-        // If not showing Capo chords then 'transpose' Capo 0 to display preferred chords
-        if (!mainActivityInterface.getPreferences().getMyPreferenceBoolean("displayCapoChords", true)) {
-            transposeTimes = 0;
-        } else {
-            transposeTimes = Integer.parseInt("0" + mainActivityInterface.getSong().getCapo());
-        }
-
-        transposeDirection = "-1";
-        return transposeString(mainActivityInterface.getSong());
-    }
-
-    private void capoKeyTranspose() {
+    public String capoKeyTranspose() {
         capoKey = numberToKey(transposeNumber(keyToNumber(mainActivityInterface.getSong().getKey()),
                 "-1", Integer.parseInt("0" + mainActivityInterface.getSong().getCapo())));
+        return capoKey;
     }
 
     private ArrayList<String> quickCapoKey(String key) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/customviews/MyToolbar.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/customviews/MyToolbar.java
@@ -214,9 +214,7 @@ public class MyToolbar extends MaterialToolbar {
             }
 
             if (!capoString.isEmpty() && !keyString.isEmpty()) {
-                int capo = Integer.parseInt(mainActivityInterface.getSong().getCapo());
-                String key = mainActivityInterface.getSong().getKey();
-                capoString += " (" + mainActivityInterface.getTranspose().getKeyBeforeCapo(capo,key) + ")";
+                capoString += (" (" + mainActivityInterface.getTranspose().capoKeyTranspose() + ")").replace(" ()","");
             }
             String thisCapoString = "";
             if (!capoString.isEmpty()) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/importsongs/ImportOnlineFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/importsongs/ImportOnlineFragment.java
@@ -401,7 +401,8 @@ public class ImportOnlineFragment extends Fragment {
                 }
                 break;
             case "SongSelect":
-                if (webString.contains("<span class=\"cproTitleLine\">")) {
+                if (webString.contains("<div id=\"LyricsText\"") ||
+                        webString.contains("<span class=\"cproTitleLine\">")) {
                     show = true;
                 }
                 break;
@@ -466,10 +467,14 @@ public class ImportOnlineFragment extends Fragment {
                 break;
             case "SongSelect":
                 Log.d(TAG,"getting here SongSelect");
-                newSong = songSelect.processContent(mainActivityInterface,newSong,webString);
+                if (webString.contains("<div id=\"LyricsText\"")) {
+                    newSong = songSelect.processContentLyricsText(mainActivityInterface, newSong, webString);
+                } else  if (webString.contains("<span class=\"cproTitleLine\">")) {
+                    newSong = songSelect.processContentChordPro(mainActivityInterface, newSong, webString);
+                }
                 break;
             case "UkuTabs":
-                Log.d("ImportOnline", "getting here UkuTabs");
+                Log.d(TAG, "getting here UkuTabs");
                 newSong = ukuTabs.processContent(newSong,webString);
                 break;
             case "HolyChords":

--- a/app/src/main/java/com/garethevans/church/opensongtablet/importsongs/SongSelect.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/importsongs/SongSelect.java
@@ -1,5 +1,8 @@
 package com.garethevans.church.opensongtablet.importsongs;
 
+import android.os.Build;
+import android.text.Html;
+
 import com.garethevans.church.opensongtablet.interfaces.MainActivityInterface;
 import com.garethevans.church.opensongtablet.songprocessing.Song;
 
@@ -7,20 +10,15 @@ public class SongSelect {
 
     // User can either click on the download link (which triggers a pdf download),
     // Or click on the extract button.  To keep it legal, this triggers the download button too!
-    // Song is effectively written in chopro.
+    // Song is effectively written in chordpro.
     // Chord lines will have the chord identifier in them.  That can be removed
-    // Text is htmlentitied - i.e. " is shown as &quot;, ' is shown as &#039;
+    // Text is html entitied - i.e. " is shown as &quot;, ' is shown as &#039;
 
-    private final String[] bitsToClear = new String[] {"</span>", "<span class=\"chordLyrics\">",
-            "<span class=\"chordWrapper\">","</code>", "<span class=\"cproSongLine\">",
-            "<pre class=\"cproSongBody\">", "<pre class=\"cproSongSection\">", "<pre class=\"cproComment\">"};
-
-    public Song processContent(MainActivityInterface mainActivityInterface,
-                               Song newSong, String s) {
+    public Song processContentChordPro(MainActivityInterface mainActivityInterface, Song newSong, String s) {
         // Get the content we want
-        s = getSubstring(s,"<span class=\"cproTitle\">","<p class=\"disclaimer\">");
+        s = getSubstring(s,"<span class=\"cproSongHeader\">","<p class=\"disclaimer\">");
 
-        newSong.setTitle(mainActivityInterface.getProcessSong().parseHTML(getHeader(s)));
+        newSong.setTitle(mainActivityInterface.getProcessSong().parseHTML(getTitle(s)));
         newSong.setFilename(newSong.getTitle());
         newSong.setFiletype("XML");
         newSong.setAuthor(mainActivityInterface.getProcessSong().parseHTML(getAuthor(s)));
@@ -29,35 +27,104 @@ public class SongSelect {
         getTempoTimeSig(newSong,s);
         newSong.setKey(getKey(s));
 
-        // Trim the song contents further
-        s = getSubstring(s,"<pre class=\"cproSongBody\">","</pre>");
+        // IV - Handle lyrics with with one or more cproSongBody where split over pages
+        StringBuilder lyricsBuilder = new StringBuilder();
+        while (s.contains("<pre class=\"cproSongBody\">")) {
+            int start = s.indexOf("<pre class=\"cproSongBody\">");
+            int end = s.indexOf("</pre>", start);
 
-        // Now split into lines and fix the content
-        StringBuilder stringBuilder = new StringBuilder();
-        String[] lines = s.split("\n");
-        for (String line:lines) {
-            line = fixHeaders(line);
-            line = fixChords(line);
-            line = mainActivityInterface.getProcessSong().parseHTML(line);
-            stringBuilder.append(line).append("\n");
+            // IV - Overwrite so that next loop finds any further SongBody
+            s = s.replaceFirst("<pre class=\"cproSongBody\">", "<xxxxxxxxxxxxxxxxxxxxxxxx>");
+
+            if (start > -1 && end > -1 && end > start) {
+                lyricsBuilder.append(s.substring(start + 26, end)).append("\n");
+            }
         }
+        String lyrics = lyricsBuilder.toString();
 
+        // Fix the content
+        lyrics = fixHeaders(lyrics);
+        lyrics = fixChords(lyrics);
+        lyrics = mainActivityInterface.getProcessSong().parseHTML(lyrics);
         // Get rid of the rest of the stuff
-        String content = stripOutTags(stringBuilder.toString());
+        lyrics = stripOutTags(lyrics);
+        // End trim
+        lyrics = lyrics.replaceAll("\\s+$", "");
 
         // Convert to OpenSongFormat
-        content = mainActivityInterface.getConvertChoPro().fromChordProToOpenSong(content);
-        newSong.setLyrics(content);
+        lyrics = mainActivityInterface.getConvertChoPro().fromChordProToOpenSong(lyrics);
+        newSong.setLyrics(lyrics);
 
         return newSong;
     }
 
-    private String getHeader(String s) {
-        return s.substring(0,s.indexOf("</span>")).trim();
+    private String getTitle(String s) {
+        // IV - Try chordpro style
+        int start = s.indexOf("<span class=\"" +
+                "cproTitle\">");
+        int end = s.indexOf("</span>",start);
+
+        // IV - Try song viewer style
+        if (start == -1) {
+            start = s.indexOf("<h2 class=\"song-viewer-title\">");
+            end = s.indexOf("</h2>",start);
+        }
+
+        // IV - Try page style
+        if (start == -1) {
+            start = s.indexOf("<div class=\"content-title\">");
+            if (start > -1) {
+                start = s.indexOf("<h1>", start);
+                end = s.indexOf("</h1>", start);
+            }
+        }
+
+        if (start>-1 && end>-1 && end>start) {
+            start = s.indexOf(">",start) + 1;
+            String t = s.substring(start,end);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                t = Html.fromHtml(t, 0).toString();
+            } else {
+                t = Html.fromHtml(t).toString();
+            }
+            return t.trim();
+        } else {
+            return "Not available";
+        }
     }
 
     private String getAuthor(String s) {
-        return getSubstring(s,"<span class=\"cproAuthors\">","</span>").trim();
+        // Extract the author
+        // IV - Try chordpro style
+        int start = s.indexOf("<span class=\"cproAuthors\">");
+        int end = s.indexOf("</span>",start);
+
+        // IV - Try song viewer style
+        if (start == -1) {
+            start = s.indexOf("<p class=\"contributor\">");
+            end = s.indexOf("</p>",start);
+        }
+
+        if (start>-1 && end>-1 && end>start) {
+            start = s.indexOf(">",start) + 1;
+            // IV - Remove line breaks, replace non breaking spaces, replace use of | as separator with comma
+            String a = s.substring(start,end).
+                    replaceAll("<br>",", ").
+                    replace("</li><li>",", ").
+                    replace("<li>","").
+                    replace ("</li>","").
+                    replaceAll("&nbsp;"," ").
+                    replaceAll("\u00A0"," ").
+                    replaceAll("\\Q |\\E",",");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                a = Html.fromHtml(a, 0).toString();
+            } else {
+                a = Html.fromHtml(a).toString();
+            }
+            return a.trim();
+        } else {
+            return "";
+        }
     }
 
     private String getKey(String s) {
@@ -75,16 +142,27 @@ public class SongSelect {
 
     private void getTempoTimeSig(Song newSong, String s) {
         s = getSubstring(s,"<span class=\"cproTempoTimeWrapper\">","</span>");
-        newSong.setTempo(getSubstring(s,"Tempo -","|").trim());
-        newSong.setTimesig(getSubstring(s,"Time -",null).trim());
+        newSong.setTempo(getSubstring(s,"Tempo -","|").trim().
+                replace("bpm", "").
+                replace("BPM", "").
+                replace("Bpm", ""));
+        newSong.setTimesig(getSubstring(s,"Time -",null).trim().
+                replace("&nbsp;"," "));
     }
 
     private String getCopyright(String s) {
+        // IV - Same class for chordpro and song viewer styles
         if (s.contains("<ul class=\"copyright\">")) {
-            s = getSubstring(s, "<ul class=\"copyright\">", "</ul>");
-            s = s.replace("<li>", "");
-            s = s.replace("</li>", " ");
-
+            s = getSubstring(s, "<ul class=\"copyright\">", "</ul>").
+            // IV - Remove line breaks, copyright, replace non breaking spaces, replace use of | as separator with comma and remove '(Admin. by)' content
+                    replace("</li><li>",", ").
+                    replace("<li>","").
+                    replace ("</li>","").
+                    replace("©","").
+                    replaceAll("&nbsp;"," ").
+                    replaceAll("\u00A0"," ").
+                    replaceAll("\\Q |\\E",",").
+                    replaceAll(" \\(Admin\\..*?\\)","");
             return s.trim();
         } else {
             return "";
@@ -92,30 +170,46 @@ public class SongSelect {
     }
 
     private String getCCLI(String s) {
-        return getSubstring(s,"<p class=\"songnumber\">CCLI Song #","</p>").trim();
+        // IV - Same class for chordpro and song viewer styles
+        // IV - Step over leading words
+        String ccli;
+        int start;
+        ccli = getSubstring(s,"<p class=\"songnumber\">CCLI Song #","</p>").trim();
+        while (ccli.contains(" ")) {
+            start = ccli.indexOf(" ");
+            ccli = ccli.substring(start + 1);
+        }
+        return ccli.trim();
     }
 
-    private String fixHeaders(String line) {
-        if (line.contains("<span class=\"cproSongSection\">")) {
-            line = getSubstring(line,"<span class=\"cproComment\">","</span>");
+    private String fixHeaders(String lyrics) {
+        int start;
+        while (lyrics.contains("<span class=\"cproSongSection\"><span class=\"cproComment\">")) {
+            start = lyrics.indexOf("<span class=\"cproSongSection\"><span class=\"cproComment\">");
+            lyrics = lyrics.substring(0, start) +
+                    (lyrics.substring(start).
+                            replaceFirst("<span class=\"cproSongSection\"><span class=\"cproComment\">","#[").
+                            replaceFirst("</span>", "]"));
         }
-        return line;
+        return lyrics;
     }
 
-    private String fixChords(String line) {
-        if (line.contains("<span class=\"chordWrapper\">")) {
-            line = line.replace("<span class=\"chordWrapper\">","[");
-            while (line.contains("<code class=\"chord\"")) {
-                int start = line.indexOf("<code class=\"chord\"");
-                int end = line.indexOf(">",start);
-                if (start>0 && end>start) {
-                    String remove = line.substring(start, end+1);
-                    line = line.replace(remove, "");
-                }
-            }
-            line = line.replace("</code>","]");
+    private String fixChords(String lyrics) {
+        // Fix the chords
+        // Chords are found in a bit like this: <span class="chordWrapper"><code class="chord" data-chordname="D<sup>2</sup>">D<sup>2</sup></code>
+        // We replace start with [< and end with ] to give: [<"D<sup>2</sup>">D<sup>2</sup>]
+        // The following stripOutTags clean up removes all "<...>" to give [D2]
+
+        int start;
+
+        while (lyrics.contains("<span class=\"chordWrapper\"><code class=\"chord\" data-chordname=\"")) {
+            start = lyrics.indexOf("<span class=\"chordWrapper\"><code class=\"chord\" data-chordname=\"");
+            lyrics = lyrics.substring(0, start) +
+                    (lyrics.substring(start).
+                            replaceFirst("<span class=\"chordWrapper\"><code class=\"chord\" data-chordname=\"","[<").
+                            replaceFirst("</code>","]"));
         }
-        return line;
+        return lyrics;
     }
 
 
@@ -140,11 +234,52 @@ public class SongSelect {
     }
 
     private String stripOutTags(String s) {
-        for (String bit:bitsToClear) {
-            s = s.replace(bit,"");
-        }
-        s = s.replaceAll("<(.*?)>", "");
+        s = s.replaceAll("\\<.*?\\>", "");
         return s;
     }
 
+    public Song processContentLyricsText(MainActivityInterface mainActivityInterface, Song newSong, String s) {
+        int start;
+        int end;
+
+        start = s.indexOf("<div class=\"song-viewer lyrics\" id=\"song-viewer\">");
+        end = s.indexOf("</div>", start);
+        if (start > -1 && end > -1 && end > start) {
+            start = s.indexOf(">", start) + 1;
+            String lyrics = s.substring(start, end).trim();
+            // IV - Drop the bottom copyright info
+            end = lyrics.indexOf("<div class=\"copyright-info\">");
+            if (end > -1) {
+                lyrics = lyrics.substring(0, end);
+            }
+            // IV - Mark a song viewer part as a tag
+            lyrics = lyrics.replaceAll("<h3 class=\"song-viewer-part\">", "<h3 class=\"song-viewer-part\">#[").
+                    replaceAll("</h3>", "]</h3>");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                lyrics = Html.fromHtml(lyrics, 0).toString();
+            } else {
+                lyrics = Html.fromHtml(lyrics).toString();
+            }
+            // IV - Remove extra line after tag
+            lyrics = lyrics.replaceAll("]\n\n", "]\n");
+
+            // The first line is the title normally
+            end = lyrics.indexOf("\n");
+            if (end > -1) {
+                newSong.setTitle(lyrics.substring(0, end).trim());
+                lyrics = lyrics.substring(end).trim();
+            }
+            // Convert to OpenSongFormat
+            newSong.setLyrics(mainActivityInterface.getConvertChoPro().fromChordProToOpenSong(lyrics));
+        } else {
+            newSong.setTitle(mainActivityInterface.getProcessSong().parseHTML(getTitle(s)));
+        }
+        newSong.setFilename(newSong.getTitle());
+        newSong.setFiletype("XML");
+        newSong.setAuthor(mainActivityInterface.getProcessSong().parseHTML(getAuthor(s)));
+        newSong.setCcli(mainActivityInterface.getProcessSong().parseHTML(getCCLI(s)));
+        newSong.setCopyright(mainActivityInterface.getProcessSong().parseHTML(getCopyright(s)));
+
+        return newSong;
+    }
 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/performance/PerformanceFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/performance/PerformanceFragment.java
@@ -931,6 +931,11 @@ public class PerformanceFragment extends Fragment {
             mainActivityInterface.getNearbyConnections().resetHostPendingSection();
         }
 
+        // Now deal with the highlighter file
+        if (mainActivityInterface.getMode().equals(mode_performance)) {
+            dealWithHighlighterFile(widthAfterScale, heightAfterScale);
+        }
+
         // Run this only when the user has stopped on a song after 2s.
         // This is important for pad use - the pad will not change while the user rapidly changes songs.
         // This is important for rapid song changes - we only run autoscroll, metronome etc. for the last song.
@@ -960,11 +965,6 @@ public class PerformanceFragment extends Fragment {
             // Deal with capo information (if required)
             mainActivityInterface.updateOnScreenInfo("capoShow");
             mainActivityInterface.dealWithCapo();
-
-            // Now deal with the highlighter file
-            if (mainActivityInterface.getMode().equals(mode_performance)) {
-                dealWithHighlighterFile(widthAfterScale, heightAfterScale);
-            }
 
             // Load up the sticky notes if the user wants them
             dealWithStickyNotes(false, false);
@@ -1045,7 +1045,11 @@ public class PerformanceFragment extends Fragment {
                                     // Hide after a certain length of time
                                     int timetohide = mainActivityInterface.getPreferences().getMyPreferenceInt("timeToDisplayHighlighter", 0);
                                     if (timetohide != 0) {
-                                        new Handler().postDelayed(() -> myView.highlighterView.setVisibility(View.GONE), timetohide);
+                                        new Handler().postDelayed(() ->  {
+                                            if (myView.highlighterView!=null) {
+                                                myView.highlighterView.setVisibility(View.GONE);
+                                            }
+                                        }, timetohide * 1000L);
                                     }
                                 } else {
                                     myView.highlighterView.post(() -> {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
@@ -81,7 +81,7 @@ public class ProcessSong {
             lineSpacing, scaleHeadings, scaleChords, scaleComments;
     private String songAutoScale;
     // Stuff for resizing/scaling
-    private int padding = 8, columns=1;
+    private int padding = 8, primaryScreenColumns=1;
     private boolean bracketsOpen = false;
     private int bracketsStyle = Typeface.NORMAL;
     private boolean curlyBrackets = true;
@@ -2411,18 +2411,27 @@ public class ProcessSong {
             if (availableWidth>currentWidth) {
                 currentWidth = availableWidth;
             }
-            columns = 1;
+            if (!presentation) {
+                // Used by primary screen highlighter file naming
+                primaryScreenColumns = 1;
+            }
             createOneColumn(sectionViews, sectionWidths, sectionHeights, column1, column2, column3, currentWidth,
                     currentHeight, columnInfo[1], presentation, songSheetTitleHeight, (int)columnInfo[4]);
 
         } else if (columnInfo[0]==2) {
             // If we have 2 force column tags, use those positions instead
-            columns = 2;
+            if (!presentation) {
+                // Used by primary screen highlighter file naming
+                primaryScreenColumns = 2;
+            }
             createTwoColumns(sectionViews, column1, column2,
                     column3, columnInfo, presentation, songSheetTitleHeight);
 
         } else if (columnInfo[0]==3) {
-            columns = 3;
+            if (!presentation) {
+                // Used by primary screen highlighter file naming
+                primaryScreenColumns = 3;
+            }
             createThreeColumns(sectionViews, column1, column2, column3, columnInfo,
                     presentation, songSheetTitleHeight);
 
@@ -3039,7 +3048,7 @@ public class ProcessSong {
             filename += "_" + song.getPdfPageCurrent();
         } else {
             //if (portrait) {  // old v5 logic which only worked for full autoscale
-            if (columns==1) {
+            if (primaryScreenColumns == 1) {
                 filename += "_p";
             } else {
                 filename += "_l";

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
@@ -1688,6 +1688,9 @@ public class ProcessSong {
         // First we process the song (could be the loaded song, or a temp song - that's why we take a reference)
         processSongIntoSections(song, presentation);
 
+        // IV - Initialise transpose capo key  - might be needed
+        mainActivityInterface.getTranspose().capoKeyTranspose();
+
         if (asPDF && mainActivityInterface.getMakePDF().getIsSetListPrinting()) {
             // This is the set list PDF print.  Items are split by empty section headers []
             // We need to now remove those and trim the section content otherwise the PDF has gaps between lines

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/SongSheetHeaders.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/SongSheetHeaders.java
@@ -101,9 +101,7 @@ public class SongSheetHeaders {
 
         if (capo!=null && !capo.isEmpty()) {
             keyCapoTempo += "| " + c.getString(R.string.capo) + ": " + capo + " ";
-            if (key!=null && !key.isEmpty()) {
-                keyCapoTempo += "(" + mainActivityInterface.getTranspose().getKeyBeforeCapo(Integer.parseInt(capo), key) + ") ";
-            }
+            keyCapoTempo += ("(" + mainActivityInterface.getTranspose().capoKeyTranspose() + ") ").replace(" ()","");
         }
 
         if (key!=null && !key.isEmpty()) {


### PR DESCRIPTION
Hello Gareth,

This upgrades v6 with v5 improved SongSelect extract logic.  Supports extract to xml for both the 'Lyrics' and 'Chords' tab.

There is something missing though.  v5 rightly also calls the click of the SongSelect download button - the downloaded PDF also added to opensongapp.

v6 should do a little more.. the "Chords" SongSelect page needs the download button 'clicked, the  "lyrics" SongSelect page also has a download button that needs clicking.   Also, we should consider support for download on the music sheet tabs as well, these would be PDF sheet music.  For the PDF files it would be good to add, if available, info from the page to the non opensongapp song DB.   We should try to handle the user directly using the SongSelect download button as well.

Following the xml extract the call of the SongSelect download 'click' to get and save the songselect PDF is outstanding in v6.  To keep our users use of SongSelect correct (within term) this needs adding asap.

Happy to discuss.

Cheers
Ian

