### PR TITLE
Fix for capitalized letters in font resource name

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
@@ -108,7 +108,7 @@ public class MyFonts {
         changeFont("fontPreso",fontPreso,presoFontHandler);
         changeFont("fontPresoInfo",fontPresoInfo,presoInfoFontHandler);
         changeFont("fontSticky",fontSticky,stickyFontHandler);
-        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/robotomono.ttf"));
+        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/RobotoMono.ttf"));
     }
 
     public void changeFont(String which, String fontName, Handler handler) {


### PR DESCRIPTION
Hi Gareth,
English is my second language.
In attempting to deploy and run your app for the first time, from Android Studio, to my physical tablet in debug mode, I encountered the following error:

> java.lang.RuntimeException font asset not found font/robotomono.ttf

The error occured while executing line 111 in class _app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java_.

Please find in this Pull Request a fix that solves the error.

Strangely enough, the error does not occurs when the app is installed on the same device from the Google Play Store.
I am assuming the error is not happening for you, or for most contributors.
The fix could nevertheless spare those in my situation from a minor headache.