### PR TITLE
Improvement to the search by tag mechanism

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
@@ -108,7 +108,7 @@ public class MyFonts {
         changeFont("fontPreso",fontPreso,presoFontHandler);
         changeFont("fontPresoInfo",fontPresoInfo,presoInfoFontHandler);
         changeFont("fontSticky",fontSticky,stickyFontHandler);
-        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/RobotoMono.ttf"));
+        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/robotomono.ttf"));
     }
 
     public void changeFont(String which, String fontName, Handler handler) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/appdata/MyFonts.java
@@ -108,7 +108,7 @@ public class MyFonts {
         changeFont("fontPreso",fontPreso,presoFontHandler);
         changeFont("fontPresoInfo",fontPresoInfo,presoInfoFontHandler);
         changeFont("fontSticky",fontSticky,stickyFontHandler);
-        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/robotomono.ttf"));
+        setMonoFont(Typeface.createFromAsset(c.getAssets(),"font/RobotoMono.ttf"));
     }
 
     public void changeFont(String which, String fontName, Handler handler) {

--- a/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
@@ -13,15 +13,12 @@ import com.garethevans.church.opensongtablet.songprocessing.Song;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.sql.Array;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class CommonSQL {
     // This is used to perform common tasks for the SQL database and NonOpenSongSQL database.
@@ -277,27 +274,25 @@ public class CommonSQL {
             sqlMatch += SQLite.COLUMN_KEY + "= ? AND ";
             args.add(keyVal);
         }
-        if (searchByTag && tagVal != null && tagVal.length() > 0 && tagVal.matches("[^; ]")) {
-            List<String> tagList = Arrays.asList(tagVal.split("(;)"));
-            for (int i = tagList.size(); i > 0; i--) {
+        if (searchByTag && tagVal != null && tagVal.length() > 0) {
+            List<String> tagList = new ArrayList<>(Arrays.asList(tagVal.split(";")));
+            for (int i = (tagList.size() - 1); i >= 0; i--) {
                 if (StringUtils.isBlank(tagList.get(i))) {
                     tagList.remove(i);
                 }
             }
-            sqlMatch += "(";
-            for (int i = 0, max = tagList.size(); i < max; i++) {
-                String tag = tagList.get(i);
-                if (!StringUtils.isBlank(tag)) {
-                    sqlMatch += SQLite.COLUMN_THEME + " LIKE ? OR ";
-                    sqlMatch += SQLite.COLUMN_ALTTHEME + " LIKE ? ";
+            if (!tagList.isEmpty()) {
+                sqlMatch += "(";
+                for (int i = 0, max = tagList.size(); i < max; i++) {
+                    sqlMatch += SQLite.COLUMN_THEME + " LIKE ? OR " + SQLite.COLUMN_ALTTHEME + " LIKE ?";
                     if (i < max - 1) {
-                        sqlMatch += "OR ";
+                        sqlMatch += " OR ";
                     }
-                    args.add("%"+tag+"%");
-                    args.add("%"+tag+"%");
+                    args.add("%"+tagList.get(i)+"%");
+                    args.add("%"+tagList.get(i)+"%");
                 }
+                sqlMatch += ") AND ";
             }
-            sqlMatch += ") AND ";
         }
         if (searchByTitle && titleVal != null && titleVal.length() > 0) {
             sqlMatch += "(" + SQLite.COLUMN_TITLE + " LIKE ? OR ";

--- a/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
@@ -15,10 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 
 public class CommonSQL {
     // This is used to perform common tasks for the SQL database and NonOpenSongSQL database.
@@ -275,21 +273,16 @@ public class CommonSQL {
             args.add(keyVal);
         }
         if (searchByTag && tagVal != null && tagVal.length() > 0) {
-            List<String> tagList = new ArrayList<>(Arrays.asList(tagVal.split(";")));
-            for (int i = (tagList.size() - 1); i >= 0; i--) {
-                if (StringUtils.isBlank(tagList.get(i))) {
-                    tagList.remove(i);
-                }
-            }
-            if (!tagList.isEmpty()) {
+            String[] tagArray = StringUtils.splitPreserveAllTokens(tagVal, ";");
+            if (tagArray.length > 0) {
                 sqlMatch += "(";
-                for (int i = 0, max = tagList.size(); i < max; i++) {
+                for (int i = 0, max = tagArray.length; i < max; i++) {
                     sqlMatch += SQLite.COLUMN_THEME + " LIKE ? OR " + SQLite.COLUMN_ALTTHEME + " LIKE ?";
                     if (i < max - 1) {
                         sqlMatch += " OR ";
                     }
-                    args.add("%"+tagList.get(i)+"%");
-                    args.add("%"+tagList.get(i)+"%");
+                    args.add("%"+tagArray[i]+"%");
+                    args.add("%"+tagArray[i]+"%");
                 }
                 sqlMatch += ") AND ";
             }


### PR DESCRIPTION
Hi again Gareth,

Here is an attempt at improving the search-by-tag mechanism.

I have noticed that searching for a tune using multiple tags currently works only if the user writes the tags in the same order as they appears in the app's database, separated by semicolon.

For example, let's say a tune is marked with the tags A and B, in this order.
To find it by tag, the user can write any of the following:

> A
> B
> A;
> ;B
> A;B

But the search will return no result if the user writes the following:

> B;A

To improve this behavior, I submit to your review the current pull request.
It's aim is to allow the user to search for tunes using multiple tags, in any order.

Sincerely,

Ludovic