### PR TITLE
Fix background images/videos to use relative paths for cross-device sync

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/ImageChooserBottomSheet.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/ImageChooserBottomSheet.java
@@ -267,25 +267,29 @@ public class ImageChooserBottomSheet extends BottomSheetCommon {
                                 switch (pickThis) {
                                     case "img1":
                                         mainActivityInterface.getPresenterSettings().setBackgroundImage1(uri);
-                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundImage1",uri.toString());
+                                        String localised1 = mainActivityInterface.getStorageAccess().fixUriToLocal(uri);
+                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundImage1",localised1);
                                         updatePreview(myView.image1, uri, false);
                                         myView.image1.performClick();
                                         break;
                                     case "img2":
                                         mainActivityInterface.getPresenterSettings().setBackgroundImage2(uri);
-                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundImage2",uri.toString());
+                                        String localised2 = mainActivityInterface.getStorageAccess().fixUriToLocal(uri);
+                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundImage2",localised2);
                                         updatePreview(myView.image2, uri, false);
                                         myView.image2.performClick();
                                         break;
                                     case "vid1":
                                         mainActivityInterface.getPresenterSettings().setBackgroundVideo1(uri);
-                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundVideo1",uri.toString());
+                                        String localised3 = mainActivityInterface.getStorageAccess().fixUriToLocal(uri);
+                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundVideo1",localised3);
                                         updatePreview(myView.video1, uri, false);
                                         myView.video1.performClick();
                                         break;
                                     case "vid2":
                                         mainActivityInterface.getPresenterSettings().setBackgroundVideo2(uri);
-                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundVideo2",uri.toString());
+                                        String localised4 = mainActivityInterface.getStorageAccess().fixUriToLocal(uri);
+                                        mainActivityInterface.getPreferences().setMyPreferenceString("backgroundVideo2",localised4);
                                         updatePreview(myView.video2, uri, false);
                                         myView.video2.performClick();
                                         break;


### PR DESCRIPTION
When background images or videos are stored in the OpenSong folder, they are now saved with relative paths (../OpenSong/...) instead of absolute device-specific paths. This allows settings to sync correctly across different devices (phones, tablets, Chromebooks, etc.) where the absolute path structure differs.

Implementation:
- Updated ImageChooserBottomSheet.java to use fixUriToLocal() when saving background URIs
- Applied to backgroundImage1, backgroundImage2, backgroundVideo1, and backgroundVideo2
- Files inside OpenSong folder use relative paths (portable)
- Files outside OpenSong folder use absolute paths (device-specific)
- Maintains backward compatibility with existing absolute paths
- Uses existing infrastructure already proven for custom logos

Technical Details:
- ImageChooserBottomSheet.java lines 270, 277, 284, 291
- Changed from uri.toString() to fixUriToLocal(uri)
- fixUriToLocal() detects "OpenSong/" in path and converts to relative
- fixLocalisedUri() on load converts relative paths back to absolute URIs