### PR TITLE
Add line preview feature for connected displays

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/filemanagement/LoadSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/filemanagement/LoadSong.java
@@ -505,6 +505,9 @@ public class LoadSong {
                                     case "preferred_instrument":
                                         thisSong.setPreferredInstrument(mainActivityInterface.getProcessSong().parseHTML(xpp.nextText()));
                                         break;
+                                    case "previewoverride":
+                                        thisSong.setPreviewoverride(mainActivityInterface.getProcessSong().parseHTML(xpp.nextText()));
+                                        break;
                                     case "aka":
                                         thisSong.setAka(mainActivityInterface.getProcessSong().parseHTML(xpp.nextText()));
                                         break;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/preferences/Preferences.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/preferences/Preferences.java
@@ -639,6 +639,7 @@ public class Preferences extends Activity {
     // setCurrentLastName               String      The last name used when saving or loading a set (def:"")
     // setLoadFirst                     boolean     Should the first item in a set be called when loading (def:true)
     // setsSortOrder                    String      Which order to sort the set list (def:az - other options za, newest, oldest);
+    // showNextLinePreview              boolean     Show preview of first line from next section on connected displays (def:false)
     // songAuthorSize                   float       The size of the song author text in the action bar (def:11.0f)
     // songAutoScale                    String      Choice of autoscale mode (Y)es, (W)idth only or (N)one (def:W)
     // songAutoScaleColumnMaximise      boolean     When autoscale is on full and columns are used, should each column scale independently to maximise font size (def:true)

--- a/app/src/main/java/com/garethevans/church/opensongtablet/presenter/PresenterSettings.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/presenter/PresenterSettings.java
@@ -20,7 +20,7 @@ public class PresenterSettings {
     private final String TAG = "PresenterSettings";
     private boolean alertOn, logoOn=true, blackscreenOn, blankscreenOn, hideInfoBar, presoShowChords,
             usePresentationOrder, presoShowClock, presoClock24h, presoClockSeconds, startedProjection,
-            presoLyricsBold, defaultPresentationText;
+            presoLyricsBold, defaultPresentationText, showNextLinePreview;
     private Uri logo, backgroundImage1, backgroundImage2, backgroundVideo1, backgroundVideo2;
     private int backgroundColor, presoTransitionTime, presoXMargin, presoYMargin, presoInfoAlign,
         presoLyricsAlign, presoLyricsVAlign, currentSection=-1;
@@ -157,6 +157,9 @@ public class PresenterSettings {
     }
     public void setDefaultPresentationText(boolean defaultPresentationText) {
         this.defaultPresentationText = defaultPresentationText;
+    }
+    public void setShowNextLinePreview(boolean showNextLinePreview) {
+        this.showNextLinePreview = showNextLinePreview;
     }
     public void setPresenterViewContentSize(float presenterViewContentSize) {
         this.presenterViewContentSize = presenterViewContentSize;
@@ -300,6 +303,9 @@ public class PresenterSettings {
     public boolean getDefaultPresentationText() {
         return defaultPresentationText;
     }
+    public boolean getShowNextLinePreview() {
+        return showNextLinePreview;
+    }
     public float getPresenterViewContentSize() {
         return presenterViewContentSize;
     }
@@ -363,6 +369,7 @@ public class PresenterSettings {
         setPresoClock24h(mainActivityInterface.getPreferences().getMyPreferenceBoolean("presoClock24h",true));
         setPresoClockSeconds(mainActivityInterface.getPreferences().getMyPreferenceBoolean("presoClockSeconds",true));
         setDefaultPresentationText(mainActivityInterface.getPreferences().getMyPreferenceBoolean("defaultPresentationText",true));
+        setShowNextLinePreview(mainActivityInterface.getPreferences().getMyPreferenceBoolean("showNextLinePreview",false));
     }
     public void getAlertPreferences() {
         setPresoAlertText(mainActivityInterface.getPreferences().getMyPreferenceString("presoAlertText",""));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.SurfaceTexture;
+import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.media.MediaPlayer;
@@ -16,6 +17,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Display;
 import android.view.Gravity;
 import android.view.Surface;
@@ -35,6 +37,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.garethevans.church.opensongtablet.R;
 import com.garethevans.church.opensongtablet.abcnotation.InlineAbcObject;
+import com.garethevans.church.opensongtablet.customviews.MyMaterialSimpleTextView;
 import com.garethevans.church.opensongtablet.databinding.CastScreenBinding;
 import com.garethevans.church.opensongtablet.interfaces.MainActivityInterface;
 import com.garethevans.church.opensongtablet.songprocessing.Song;
@@ -914,6 +917,28 @@ public class SecondaryDisplay extends Presentation {
                         setSongInLayout(mainActivityInterface.getSong(),
                                 false, true);
 
+                // Add preview lines if feature is enabled
+                // Check for per-song override first, then global setting
+                // Only for Presenter/Stage modes, not Performance mode (which shows all sections)
+                // Exclude PDF, IMG files and image slide collections
+                boolean showPreview;
+                String override = mainActivityInterface.getSong().getPreviewoverride();
+                if (override != null && override.equals("force_on")) {
+                    showPreview = true;
+                } else if (override != null && override.equals("force_off")) {
+                    showPreview = false;
+                } else {
+                    showPreview = mainActivityInterface.getPresenterSettings().getShowNextLinePreview();
+                }
+
+                if (showPreview &&
+                    !mainActivityInterface.getMode().equals(c.getString(R.string.mode_performance)) &&
+                    !mainActivityInterface.getSong().getFiletype().equals("PDF") &&
+                    !mainActivityInterface.getSong().getFiletype().equals("IMG") &&
+                    !mainActivityInterface.getSong().getFolder().contains("**Image")) {
+                    addPreviewLinesToViews();
+                }
+
                 Log.d(TAG, "webView count:" + mainActivityInterface.getAbcNotation().getInlineAbcObjects().size());
                 // Draw them to the screen test layout for measuring
                 waitingOnViewsToDraw = secondaryViews.size();
@@ -1498,5 +1523,84 @@ public class SecondaryDisplay extends Presentation {
             }
             crossFadeBackgrounds();
         }
+    }
+
+    // Next line preview feature methods
+    private void addPreviewLinesToViews() {
+        ArrayList<String> sections = mainActivityInterface.getSong().getPresoOrderSongSections();
+
+        for (int i = 0; i < secondaryViews.size() - 1; i++) {  // -1 to skip last section
+            View currentView = secondaryViews.get(i);
+            if (currentView instanceof LinearLayout) {
+                LinearLayout layout = (LinearLayout) currentView;
+                String nextSectionPreview = getFirstLyricLine(sections.get(i + 1));
+
+                if (!nextSectionPreview.isEmpty()) {
+                    MyMaterialSimpleTextView previewTextView = createPreviewTextView(nextSectionPreview);
+                    layout.addView(previewTextView);
+                }
+            }
+        }
+    }
+
+    private String getFirstLyricLine(String section) {
+        if (section == null || section.trim().isEmpty()) {
+            return "";
+        }
+
+        String[] lines = section.split("\n");
+        for (String line : lines) {
+            line = line.trim();
+            // Skip empty lines
+            if (line.isEmpty()) {
+                continue;
+            }
+            // Skip heading lines [Verse 1], [Chorus], etc.
+            if (line.startsWith("[") && line.endsWith("]")) {
+                continue;
+            }
+            // Skip comment lines (starting with {)
+            if (line.startsWith("{")) {
+                continue;
+            }
+            // Skip chord-only lines (first non-space character is .)
+            if (line.startsWith(".")) {
+                continue;
+            }
+            // This is the first lyric line
+            return line;
+        }
+        return "";
+    }
+
+    private MyMaterialSimpleTextView createPreviewTextView(String text) {
+        MyMaterialSimpleTextView textView = new MyMaterialSimpleTextView(c, null);
+
+        // Match current lyric styling
+        textView.setText(text);
+        textView.setTextColor(mainActivityInterface.getMyThemeColors().getPresoFontColor());
+        // Use the same base font size as lyrics (will be scaled with the view)
+        textView.setTextSize(mainActivityInterface.getProcessSong().getDefFontSize());
+
+        // Apply transparency (0.5 = 50% transparent)
+        textView.setAlpha(0.5f);
+
+        // Match lyric alignment
+        textView.setGravity(mainActivityInterface.getPresenterSettings().getPresoLyricsAlign());
+
+        // Apply typeface
+        if (mainActivityInterface.getPresenterSettings().getPresoLyricsBold()) {
+            textView.setTypeface(mainActivityInterface.getMyFonts().getPresoFont(), Typeface.BOLD);
+        } else {
+            textView.setTypeface(mainActivityInterface.getMyFonts().getPresoFont(), Typeface.NORMAL);
+        }
+
+        // Layout params - use MATCH_PARENT width for proper alignment
+        textView.setLayoutParams(new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ));
+
+        return textView;
     }
 }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplaySettingsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplaySettingsFragment.java
@@ -217,6 +217,7 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
 
         myView.infoAlign.setSliderPos(gravityToSliderPosition(mainActivityInterface.getPresenterSettings().getPresoInfoAlign()));
         myView.hideInfoBar.setChecked(mainActivityInterface.getPresenterSettings().getHideInfoBar());
+        myView.showNextLinePreview.setChecked(mainActivityInterface.getPresenterSettings().getShowNextLinePreview());
 
         myView.titleTextSize.setValue(mainActivityInterface.getPresenterSettings().getPresoTitleTextSize());
         myView.authorTextSize.setValue(mainActivityInterface.getPresenterSettings().getPresoAuthorTextSize());
@@ -298,6 +299,12 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
         myView.hideInfoBar.setOnCheckedChangeListener((compoundButton, b) -> {
             mainActivityInterface.getPreferences().setMyPreferenceBoolean("hideInfoBar",b);
             mainActivityInterface.getPresenterSettings().setHideInfoBar(b);
+            refreshSection();
+        });
+
+        myView.showNextLinePreview.setOnCheckedChangeListener((compoundButton, b) -> {
+            mainActivityInterface.getPreferences().setMyPreferenceBoolean("showNextLinePreview",b);
+            mainActivityInterface.getPresenterSettings().setShowNextLinePreview(b);
             refreshSection();
         });
 

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/EditSongFragmentFeatures.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/EditSongFragmentFeatures.java
@@ -120,13 +120,23 @@ public class EditSongFragmentFeatures extends Fragment {
         // The capo
         setupCapo();
 
-        // Check for overrides
+        // Check for ABC overrides
         if (mainActivityInterface.getProcessSong().getHasAbcOffOverride(mainActivityInterface.getTempSong())) {
             myView.overrideAbcSlider.setSliderPos(2);
         } else if (mainActivityInterface.getProcessSong().getHasAbcOnOverride(mainActivityInterface.getTempSong())) {
             myView.overrideAbcSlider.setSliderPos(1);
         } else {
             myView.overrideAbcSlider.setSliderPos(0);
+        }
+
+        // Check for preview overrides
+        String previewOverride = mainActivityInterface.getTempSong().getPreviewoverride();
+        if (previewOverride != null && previewOverride.equals("force_off")) {
+            myView.overridePreviewSlider.setSliderPos(2);
+        } else if (previewOverride != null && previewOverride.equals("force_on")) {
+            myView.overridePreviewSlider.setSliderPos(1);
+        } else {
+            myView.overridePreviewSlider.setSliderPos(0);
         }
 
         // The pad file
@@ -387,7 +397,7 @@ public class EditSongFragmentFeatures extends Fragment {
 
             myView.tapTempo.setOnClickListener(button -> mainActivityInterface.getMetronome().tapTempo());
 
-            // The sticky notes override
+            // The ABC override
             myView.overrideAbcSlider.addOnChangeListener((slider, value, fromUser) -> {
                 // All options should clear existing override value
                 mainActivityInterface.getProcessSong().removeAbcOverrides(mainActivityInterface.getTempSong(), true);
@@ -405,6 +415,21 @@ public class EditSongFragmentFeatures extends Fragment {
                             mainActivityInterface.getTempSong(), false);
                 }
                 myView.overrideAbcSlider.updateAlphas();
+            });
+
+            // The preview override
+            myView.overridePreviewSlider.addOnChangeListener((slider, value, fromUser) -> {
+                if (value==1) {
+                    // Force preview ON
+                    mainActivityInterface.getTempSong().setPreviewoverride("force_on");
+                } else if (value==2) {
+                    // Force preview OFF
+                    mainActivityInterface.getTempSong().setPreviewoverride("force_off");
+                } else {
+                    // Use global setting (no override)
+                    mainActivityInterface.getTempSong().setPreviewoverride("");
+                }
+                myView.overridePreviewSlider.updateAlphas();
             });
 
             myView.preferredInstrument.addTextChangedListener(new MyTextWatcher("preferredinstrument"));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/ProcessSong.java
@@ -208,6 +208,7 @@ public class ProcessSong {
         thisSong.setKey(fixNullValues(thisSong.getKey()));
         thisSong.setKeyOriginal(fixNullValues(thisSong.getKeyOriginal()));
         thisSong.setPreferredInstrument(fixNullValues(thisSong.getPreferredInstrument()));
+        thisSong.setPreviewoverride(fixNullValues(thisSong.getPreviewoverride()));
         thisSong.setAka(fixNullValues(thisSong.getAka()));
         thisSong.setMidi(fixNullValues(thisSong.getMidi()));
         thisSong.setMidiindex(fixNullValues(thisSong.getMidiindex()));
@@ -248,6 +249,10 @@ public class ProcessSong {
         // If we have set a preferred instrument for chord diagrams, add this to the xml file (no point if empty)
         if (thisSong.getPreferredInstrument()!=null && !thisSong.getPreferredInstrument().isEmpty()) {
             myNEWXML += "  <preferred_instrument>" + parseToHTMLEntities(thisSong.getPreferredInstrument().trim()) + "</preferred_instrument>\n";
+        }
+        // If we have set a preview override, add this to the xml file (no point if empty)
+        if (thisSong.getPreviewoverride()!=null && !thisSong.getPreviewoverride().isEmpty()) {
+            myNEWXML += "  <previewoverride>" + parseToHTMLEntities(thisSong.getPreviewoverride().trim()) + "</previewoverride>\n";
         }
         myNEWXML += "  <aka>" + parseToHTMLEntities(thisSong.getAka()).trim() + "</aka>\n";
         myNEWXML += "  <midi>" + parseToHTMLEntities(thisSong.getMidi()).trim() + "</midi>\n";

--- a/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/Song.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/songprocessing/Song.java
@@ -40,6 +40,7 @@ public class Song implements Serializable {
     private String key="";
     private String keyoriginal="";
     private String preferredInstrument = "";
+    private String previewoverride="";
     private String timesig="";
     private String tempo="";
     private String aka="";
@@ -150,6 +151,9 @@ public class Song implements Serializable {
     }
     public String getPreferredInstrument() {
         return preferredInstrument;
+    }
+    public String getPreviewoverride() {
+        return previewoverride;
     }
     public String getTimesig() {return timesig;}
     public String getTempo() {
@@ -318,6 +322,9 @@ public class Song implements Serializable {
     public void setPreferredInstrument(String preferredInstrument) {
         this.preferredInstrument = preferredInstrument;
     }
+    public void setPreviewoverride(String previewoverride) {
+        this.previewoverride = previewoverride;
+    }
     public void setTimesig(String timesig) {
         this.timesig = timesig;
     }
@@ -447,6 +454,7 @@ public class Song implements Serializable {
         this.key = toCopy.key;
         this.keyoriginal = toCopy.keyoriginal;
         this.preferredInstrument = toCopy.preferredInstrument;
+        this.previewoverride = toCopy.previewoverride;
         this.timesig = toCopy.timesig;
         this.tempo = toCopy.tempo;
         this.aka = toCopy.aka;

--- a/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/CommonSQL.java
@@ -167,6 +167,7 @@ public class CommonSQL {
         values.put(SQLite.COLUMN_KEY, thisSong.getKey());
         values.put(SQLite.COLUMN_KEY_ORIGINAL, thisSong.getKeyOriginal());
         values.put(SQLite.COLUMN_PREFERRED_INSTRUMENT, thisSong.getPreferredInstrument());
+        values.put(SQLite.COLUMN_PREVIEWOVERRIDE, thisSong.getPreviewoverride());
         values.put(SQLite.COLUMN_TIMESIG, mainActivityInterface.getMetronome().fixInvalidTimeSignature(thisSong.getTimesig(),false));
         values.put(SQLite.COLUMN_AKA, thisSong.getAka());
         values.put(SQLite.COLUMN_AUTOSCROLL_DELAY, thisSong.getAutoscrolldelay());
@@ -564,6 +565,7 @@ public class CommonSQL {
         thisSong.setKey(getValue(cursor, SQLite.COLUMN_KEY));
         thisSong.setKeyOriginal(getValue(cursor, SQLite.COLUMN_KEY_ORIGINAL));
         thisSong.setPreferredInstrument(getValue(cursor, SQLite.COLUMN_PREFERRED_INSTRUMENT));
+        thisSong.setPreviewoverride(getValue(cursor, SQLite.COLUMN_PREVIEWOVERRIDE));
         thisSong.setTimesig(getValue(cursor, SQLite.COLUMN_TIMESIG));
         thisSong.setAka(getValue(cursor, SQLite.COLUMN_AKA));
         thisSong.setAutoscrolldelay(getValue(cursor, SQLite.COLUMN_AUTOSCROLL_DELAY));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/SQLite.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/SQLite.java
@@ -55,6 +55,7 @@ public class SQLite {
     padfile
     padloop
     preferredinstrument (preferred_instrument)
+    previewoverride
     presentationorder (presentation)
     songid
     theme
@@ -91,6 +92,7 @@ public class SQLite {
     public static final String COLUMN_KEY = "key";
     public static final String COLUMN_KEY_ORIGINAL = "keyoriginal";
     public static final String COLUMN_PREFERRED_INSTRUMENT = "preferredinstrument";
+    public static final String COLUMN_PREVIEWOVERRIDE = "previewoverride";
     public static final String COLUMN_TIMESIG = "timesig";
     public static final String COLUMN_AKA = "aka";
     public static final String COLUMN_AUTOSCROLL_DELAY = "autoscrolldelay";
@@ -138,6 +140,7 @@ public class SQLite {
                     + COLUMN_KEY + " TEXT,"
                     + COLUMN_KEY_ORIGINAL + " TEXT,"
                     + COLUMN_PREFERRED_INSTRUMENT + " TEXT,"
+                    + COLUMN_PREVIEWOVERRIDE + " TEXT,"
                     + COLUMN_TIMESIG + " TEXT,"
                     + COLUMN_AKA + " TEXT,"
                     + COLUMN_AUTOSCROLL_DELAY + " TEXT,"

--- a/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/SQLiteHelper.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/sqlite/SQLiteHelper.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 public class SQLiteHelper extends SQLiteOpenHelper {
 
     // Database Version
-    private static final int DATABASE_VERSION = 8;
+    private static final int DATABASE_VERSION = 9;
     private final Context c;
     private final MainActivityInterface mainActivityInterface;
     @SuppressWarnings("FieldCanBeLocal")

--- a/app/src/main/res/layout/edit_song_features.xml
+++ b/app/src/main/res/layout/edit_song_features.xml
@@ -254,6 +254,24 @@
                 app:textC="@string/override_on"
                 app:textR="@string/override_off"/>
 
+            <com.garethevans.church.opensongtablet.customviews.MyMaterialSimpleTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="0dp"
+                android:text="@string/override_preview" />
+
+            <com.garethevans.church.opensongtablet.customviews.TextThreeSlider
+                android:id="@+id/overridePreviewSlider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="0dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginBottom="32dp"
+                app:textL="@string/override_none"
+                app:textC="@string/override_on"
+                app:textR="@string/override_off"/>
+
             <com.garethevans.church.opensongtablet.customviews.MyMaterialEditText
                 android:id="@+id/customChords"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/settings_display_connected.xml
+++ b/app/src/main/res/layout/settings_display_connected.xml
@@ -236,6 +236,14 @@
             android:hint="@string/info_text_autohide_info"
             android:text="@string/info_text_autohide" />
 
+        <com.garethevans.church.opensongtablet.customviews.MyMaterialSwitch
+            android:id="@+id/showNextLinePreview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/show_next_line_preview_hint"
+            android:text="@string/show_next_line_preview" />
+
         <LinearLayout
             android:id="@+id/infoSizes"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Force show</string>
     <string name="override_scale_explanation">As die autoscale lettergrootte is minder as die verlangde minimum lettergrootte, wil jy die jeug om te ignoreer om \'n ander skaal metode? Die gebruik van hierdie opsies kan jou dwing om horisontaal en vertikaal blaai in \'n lied.</string>
     <string name="override_sticky">Ignoreer outomatiese plaknootvertoning vir hierdie liedjie</string>
+    <string name="override_preview">Ignoreer volgende lyn voorskou vertoning vir hierdie liedjie</string>
     <string name="override_widthautoscale">Ignoreer breedte net skalering geen autoscale</string>
     <string name="overwrite">Oorskryf bestaande item</string>
     <string name="overwrite_info">Enige bypassende lêers wat jy reeds het, sal deur die gasheerlêers oorgeskryf word</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Vertoon lirieke wat in die liedjie gevind word</string>
     <string name="show_next_in_set">Wys volgende liedjie in stel</string>
     <string name="show_next_prev_in_song_menu">Wys ook vorige/volgende vir liedjies wat nie in \'n stel is nie (gebruik liedjie-kieslys)</string>
+    <string name="show_next_line_preview">Wys volgende reël voorskou</string>
+    <string name="show_next_line_preview_hint">Vertoon die eerste reël van die volgende afdeling aan die onderkant van die skerm</string>
     <string name="show_prev_song">Wys vorige liedjie in stel</string>
     <string name="show_songs">Wys liedjies</string>
     <string name="show_tempo">Wys tempo in die titel</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Silová show</string>
     <string name="override_scale_explanation">Je-li velikost písma Autoscale je nižší než požadovaná minimální velikosti písma, chcete aplikaci přepsat na jinou metodu škálování? Pomocí těchto voleb vás může nutit posouvat horizontálně i vertikálně v písni.</string>
     <string name="override_sticky">Přepsat automatické zobrazení poznámek pro tuto skladbu</string>
+    <string name="override_preview">Přepsat zobrazení náhledu dalšího řádku pro tuto skladbu</string>
     <string name="override_widthautoscale">Šířka Přepis pouze škálování žádné škálování</string>
     <string name="overwrite">Přepsat existující položku</string>
     <string name="overwrite_info">Všechny odpovídající soubory, které již máte, budou přepsány hostitelskými soubory</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Zobrazit text nalezený v písni</string>
     <string name="show_next_in_set">Zobrazit další skladbu v sadě</string>
     <string name="show_next_prev_in_song_menu">Zobrazit také předchozí/následující pro skladby, které nejsou v sadě (pomocí nabídky skladeb)</string>
+    <string name="show_next_line_preview">Zobrazit náhled dalšího řádku</string>
+    <string name="show_next_line_preview_hint">Zobrazit první řádek další sekce ve spodní části obrazovky</string>
     <string name="show_prev_song">Zobrazit předchozí skladbu v sadě</string>
     <string name="show_songs">Zobrazit skladby</string>
     <string name="show_tempo">Wys tempo v názvu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Show erzwingen</string>
     <string name="override_scale_explanation">Wenn die Schriftgröße bei automatischer Skalierung kleiner ist als die gewünschte Mindestschriftgröße, möchten Sie, dass die App dann auf eine andere Skalierungsmethode umschaltet? Diese Option kann dazu führen, dass Sie horizontal und vertikal in einem Song scrollen müssen.</string>
     <string name="override_sticky">Überschreiben Sie die automatische Anzeige von Haftnotizen für dieses Lied</string>
+    <string name="override_preview">Überschreiben Sie die Vorschau der nächsten Zeile für dieses Lied</string>
     <string name="override_widthautoscale">Automatische Skalierung auf Breite ignorieren und nicht automatisch skalieren</string>
     <string name="overwrite">Existierendes Element überschreiben</string>
     <string name="overwrite_info">Alle übereinstimmenden Dateien, die Sie bereits haben, werden durch die Hostdateien überschrieben</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Im Song gefundene Liedtexte anzeigen</string>
     <string name="show_next_in_set">Nächsten Song im Set anzeigen</string>
     <string name="show_next_prev_in_song_menu">Auch vorherige/nächste für Songs anzeigen, die nicht in einem Set enthalten sind (über das Song-Menü)</string>
+    <string name="show_next_line_preview">Vorschau der nächsten Zeile anzeigen</string>
+    <string name="show_next_line_preview_hint">Zeige die erste Zeile des nächsten Abschnitts am unteren Bildschirmrand an</string>
     <string name="show_prev_song">Vorherigen Song im Set anzeigen</string>
     <string name="show_songs">Lieder zeigen</string>
     <string name="show_tempo">Tempo im Titel anzeigen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -823,6 +823,7 @@
     <string name="override_on">Επίδειξη δύναμης</string>
     <string name="override_scale_explanation">If the autoscale font size is less than the desired minimum font size, do you want the app to override to a different scaling method?  Using these options may force you to scroll horizontally and vertically in a song</string>
     <string name="override_sticky">Παράκαμψη της αυτόματης εμφάνισης αυτοκόλλητων σημειώσεων για αυτό το τραγούδι</string>
+    <string name="override_preview">Παράκαμψη εμφάνισης προεπισκόπησης επόμενης γραμμής για αυτό το τραγούδι</string>
     <string name="override_widthautoscale">Override width only scaling to no autoscale</string>
     <string name="overwrite">Αντικατάσταση του υπάρχοντος αντικειμένου</string>
     <string name="overwrite_info">Τυχόν αρχεία που ταιριάζουν ήδη θα αντικατασταθούν από τα αρχεία κεντρικού υπολογιστή</string>
@@ -1076,6 +1077,8 @@
     <string name="show_lyrics_info">Εμφάνιση στίχων που βρέθηκαν στο τραγούδι</string>
     <string name="show_next_in_set">Εμφάνιση επόμενου τραγουδιού στην σειρά</string>
     <string name="show_next_prev_in_song_menu">Εμφάνιση επίσης προηγούμενου/επόμενου για τραγούδια που δεν ανήκουν σε σύνολο (χρησιμοποιώντας το μενού τραγουδιών)</string>
+    <string name="show_next_line_preview">Εμφάνιση προεπισκόπησης επόμενης γραμμής</string>
+    <string name="show_next_line_preview_hint">Εμφάνιση της πρώτης γραμμής της επόμενης ενότητας στο κάτω μέρος της οθόνης</string>
     <string name="show_prev_song">Εμφάνιση προηγούμενου τραγουδιού στο σετ</string>
     <string name="show_songs">Εμφάνιση τραγουδιών</string>
     <string name="show_tempo">Εμφάνιση ρυθμού στον τίτλο</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">espectáculo de fuerza</string>
     <string name="override_scale_explanation">Si el tamaño de la fuente autoescala es menor que el tamaño mínimo de la letra deseada, ¿desea la aplicación para anular a un método de escala diferente? El uso de estas opciones le puede obligar a desplazarse horizontal y verticalmente en una canción.</string>
     <string name="override_sticky">Anular la visualización automática de notas adhesivas para esta canción</string>
+    <string name="override_preview">Anular vista previa de la siguiente línea para esta canción</string>
     <string name="override_widthautoscale">Ancho de anulación únicamente el escalado a ninguna autoescala</string>
     <string name="overwrite">Sobrescribir elemento existente</string>
     <string name="overwrite_info">Cualquier archivo coincidente que ya tenga será sobrescrito por los archivos del host.</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Mostrar la letra encontrada en la canción</string>
     <string name="show_next_in_set">Mostrar siguiente canción en conjunto</string>
     <string name="show_next_prev_in_song_menu">También muestra anterior/siguiente para canciones que no están en un conjunto (usando el menú de canciones)</string>
+    <string name="show_next_line_preview">Mostrar vista previa de la siguiente línea</string>
+    <string name="show_next_line_preview_hint">Mostrar la primera línea de la siguiente sección en la parte inferior de la pantalla</string>
     <string name="show_prev_song">Mostrar la canción anterior en el conjunto</string>
     <string name="show_songs">Mostrar canciones</string>
     <string name="show_tempo">Mostrar tempo en el título</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Spectacle de force</string>
     <string name="override_scale_explanation">Si la taille de la police de autoscale est inférieure à la taille minimale souhaitée, voulez-vous l\'application pour passer outre à une méthode de mise à l\'échelle différente? L\'utilisation de ces options peuvent vous forcer à faire défiler horizontalement et verticalement dans une chanson.</string>
     <string name="override_sticky">Remplacer l\'affichage automatique des notes autocollantes pour cette chanson</string>
+    <string name="override_preview">Remplacer l\'affichage de l\'aperçu de la ligne suivante pour cette chanson</string>
     <string name="override_widthautoscale">Largeur remplacer seulement mise à l\'échelle ne autoscale</string>
     <string name="overwrite">Ecraser l\'élément existant</string>
     <string name="overwrite_info">Tous les fichiers correspondants que vous possédez déjà seront écrasés par les fichiers hôtes</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Afficher les paroles trouvées dans la chanson</string>
     <string name="show_next_in_set">Montrer la chanson suivante de la liste</string>
     <string name="show_next_prev_in_song_menu">Afficher également précédent/suivant pour les chansons qui ne font pas partie d\'un ensemble (à l\'aide du menu des chansons)</string>
+    <string name="show_next_line_preview">Afficher l\'aperçu de la ligne suivante</string>
+    <string name="show_next_line_preview_hint">Afficher la première ligne de la section suivante en bas de l\'écran</string>
     <string name="show_prev_song">Afficher la chanson précédente dans le set</string>
     <string name="show_songs">Afficher les chansons</string>
     <string name="show_tempo">Afficher le tempo dans le titre</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Erőshow</string>
     <string name="override_scale_explanation">Ha az automatikus átméretezés betűméret kisebb, mint a kívánt minimális betűméret, akarsz az alkalmazást, hogy felülbírálja a különböző méretezési módszer? Ezen opciók lehet kényszeríteni, hogy görgetni függőlegesen és vízszintesen egy dalt.</string>
     <string name="override_sticky">Az automatikus cetlik megjelenítés felülbírálása ehhez a dalhoz</string>
+    <string name="override_preview">A következő sor előnézet megjelenítésének felülbírálása ehhez a dalhoz</string>
     <string name="override_widthautoscale">Felülírása szélessége csak skálázott nem autoscale</string>
     <string name="overwrite">Felülírja a meglévő elem</string>
     <string name="overwrite_info">A már meglévő egyező fájlokat felülírják a gazdagép fájlok</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">A dalban található szövegek megjelenítése</string>
     <string name="show_next_in_set">Mutasd következő számot set</string>
     <string name="show_next_prev_in_song_menu">Előző/következő megjelenítése a készletben nem szereplő daloknál is (a dalmenü használatával)</string>
+    <string name="show_next_line_preview">Következő sor előnézetének megjelenítése</string>
+    <string name="show_next_line_preview_hint">Jelenítse meg a következő szakasz első sorát a képernyő alján</string>
     <string name="show_prev_song">Előző dal megjelenítése a készletben</string>
     <string name="show_songs">Dalok megjelenítése</string>
     <string name="show_tempo">Tempó megjelenítése a címben</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Visualizza sempre</string>
     <string name="override_scale_explanation">Se la dimensione del carattere calcolata dal ridimensionamento automatico è inferiore alla dimensione del carattere minimo desiderato, vuoi che l\'app utilizzi un metodo di scala diversa? L\'utilizzo di questa opzione può costringere a scorrere il testo del brano orizzontalmente e verticalmente.</string>
     <string name="override_sticky">Ignora la visualizzazione automatica delle note adesive per questo brano</string>
+    <string name="override_preview">Ignora la visualizzazione dell\'anteprima della riga successiva per questo brano</string>
     <string name="override_widthautoscale">Ignora il ridimensionamento automatico alla larghezza dello schermo</string>
     <string name="overwrite">Sovrascrivi elemento esistente</string>
     <string name="overwrite_info">Tutti i files corrispondenti già presenti, verranno sovrascritti dai files ricevuti dall\'host</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Visualizza i testi presenti nel brano</string>
     <string name="show_next_in_set">Visualizza il brano successivo in scaletta</string>
     <string name="show_next_prev_in_song_menu">Visualizza anche precedente/successivo per i brani non in scaletta (utilizzando il menu dei brani)</string>
+    <string name="show_next_line_preview">Mostra anteprima riga successiva</string>
+    <string name="show_next_line_preview_hint">Visualizza la prima riga della sezione successiva nella parte inferiore dello schermo</string>
     <string name="show_prev_song">Visualizza il brano precedente in scaletta</string>
     <string name="show_songs">Visualizza i brani</string>
     <string name="show_tempo">Visualizza il tempo nella barra del titolo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">強制ショー</string>
     <string name="override_scale_explanation">オートスケールのフォントサイズが希望最小フォントサイズより小さい場合は、アプリが異なるスケーリング方法に上書きしたいですか？これらのオプションを使用すると、曲に水平方向と垂直方向にスクロールすることを強制することができます。</string>
     <string name="override_sticky">この曲の自動付箋表示をオーバーライドする</string>
+    <string name="override_preview">この曲の次の行のプレビュー表示を上書きする</string>
     <string name="override_widthautoscale">オートスケールのフォントサイズが希望最小フォントサイズより小さい場合は、アプリが異なるスケーリング方法に上書きしたいですか？これらのオプションを使用すると、曲に水平方向と垂直方向にスクロールすることを強制することができます。オーバーライド幅のみなしオートスケールへのスケーリング</string>
     <string name="overwrite">既存のアイテムを上書き</string>
     <string name="overwrite_info">すでに存在する一致するファイルはホスト ファイルによって上書きされます</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">曲に含まれる歌詞を表示する</string>
     <string name="show_next_in_set">セット内の次の曲を表示します</string>
     <string name="show_next_prev_in_song_menu">セットにない曲の前/次も表示（曲メニューを使用）</string>
+    <string name="show_next_line_preview">次の行のプレビューを表示</string>
+    <string name="show_next_line_preview_hint">次のセクションの最初の行を画面下部に表示します</string>
     <string name="show_prev_song">セット内の前の曲を表示する</string>
     <string name="show_songs">曲を表示する</string>
     <string name="show_tempo">タイトルにテンポを表示する</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Siłowe przedstawienie</string>
     <string name="override_scale_explanation">Jeśli rozmiar czcionki autoskalowania jest mniejszy niż preferowany minimalny rozmiar czcionki, czy chcesz zastosować inną metodę skalowania? Korzystanie z tych opcji może zmusić cię do przewijania piosenki w pionie i w poziomie.</string>
     <string name="override_sticky">Zastąp automatyczne wyświetlanie notatki samoprzylepnej dla tego utworu</string>
+    <string name="override_preview">Zastąp wyświetlanie podglądu następnego wiersza dla tego utworu</string>
     <string name="override_widthautoscale">Zmień tryb skalowania \'tylko szerokość\' na brak automatycznego skalowania</string>
     <string name="overwrite">Zastąp istniejący element</string>
     <string name="overwrite_info">Wszelkie pasujące pliki, które już posiadasz, zostaną zastąpione plikami hosta</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Wyświetl teksty znalezione w piosence</string>
     <string name="show_next_in_set">Pokaż następną piosenkę w zestawie</string>
     <string name="show_next_prev_in_song_menu">Pokaż również poprzednie/następne piosenki spoza zestawu (przy użyciu menu piosenki)</string>
+    <string name="show_next_line_preview">Pokaż podgląd następnej linii</string>
+    <string name="show_next_line_preview_hint">Wyświetl pierwszą linię następnej sekcji na dole ekranu</string>
     <string name="show_prev_song">Pokaż poprzednią piosenkę w zestawie</string>
     <string name="show_songs">Pokaż piosenki</string>
     <string name="show_tempo">Pokaż tempo w tytule</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Forçar show</string>
     <string name="override_scale_explanation">Se o tamanho da fonte autoscale é menor do que o tamanho da fonte mínimo desejado, você quer o aplicativo para substituir a um método de escalonamento diferente? Utilizando estas opções pode forçá-lo a rolar horizontalmente e verticalmente em uma canção.</string>
     <string name="override_sticky">Substituir a exibição automática de notas adesivas para esta música</string>
+    <string name="override_preview">Substituir a exibição de visualização da próxima linha para esta música</string>
     <string name="override_widthautoscale">Width override única escala para não autoscale</string>
     <string name="overwrite">Substituir item existente</string>
     <string name="overwrite_info">Todos os arquivos correspondentes que você já possui serão substituídos pelos arquivos host</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Exibir letras encontradas na música</string>
     <string name="show_next_in_set">Mostre a próxima canção em conjunto</string>
     <string name="show_next_prev_in_song_menu">Também mostrar anterior/seguinte para músicas que não estão em um conjunto (usando o menu de músicas)</string>
+    <string name="show_next_line_preview">Mostrar pré-visualização da próxima linha</string>
+    <string name="show_next_line_preview_hint">Exibir a primeira linha da próxima seção na parte inferior da tela</string>
     <string name="show_prev_song">Mostrar música anterior no set</string>
     <string name="show_songs">Mostrar músicas</string>
     <string name="show_tempo">Mostrar andamento no título</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Принудительно показать</string>
     <string name="override_scale_explanation">Если размер автомасштабируемго шрифта меньше требуемого минимального размера шрифта, вы хотите, чтобы приложение применяло другой метод масштабирования? Это может заставить вас прокручивать песню по горизонтали и вертикали</string>
     <string name="override_sticky">Переопределить автоматическое отображение заметок для этой песни</string>
+    <string name="override_preview">Переопределить отображение предварительного просмотра следующей строки для этой песни</string>
     <string name="override_widthautoscale">Принудительное отключение автомасштабирования вместо автомасштабирования по ширине</string>
     <string name="overwrite">Переписать существующую</string>
     <string name="overwrite_info">Любые соответствующие файлы, которые у вас уже есть, будут перезаписаны файлами хоста.</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Показать текст, записанный в песне</string>
     <string name="show_next_in_set">Показ следующей песни в сетлисте</string>
     <string name="show_next_prev_in_song_menu">Показывать кнопки \'предыдущий/следующий\' также и для песен, которых нет в сетлисте (двигаться по индексу песенника)</string>
+    <string name="show_next_line_preview">Показать предварительный просмотр следующей строки</string>
+    <string name="show_next_line_preview_hint">Показать первую строку следующего раздела внизу экрана</string>
     <string name="show_prev_song">Показать предыдущую песню в сетлисте</string>
     <string name="show_songs">Показать песни</string>
     <string name="show_tempo">Показывать темп в названии</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">බල සංදර්ශන</string>
     <string name="override_scale_explanation">ස්වයංක්‍රීය පරිමාණ අකුරු ප්‍රමාණය අපේක්ෂිත අවම අකුරු ප්‍රමාණයට වඩා අඩු නම්, ඔබට යෙදුම වෙනස් පරිමාණ ක්‍රමයකට ප්‍රතික්‍ෂේප කිරීමට අවශ්‍යද?  මෙම විකල්ප භාවිතා කිරීමෙන් ගීතයක තිරස් අතට සහ සිරස් අතට අනුචලනය කිරීමට ඔබට බල කළ හැක</string>
     <string name="override_sticky">මෙම ගීතය සඳහා ස්වයංක්‍රීය ඇලෙන සුළු සටහන් සංදර්ශකය අභිබවා යන්න</string>
+    <string name="override_preview">මෙම ගීතය සඳහා මීළඟ පේළියේ පෙරදසුන් සංදර්ශකය අභිබවා යන්න</string>
     <string name="override_widthautoscale">ප්‍රතික්‍ෂේප කරන්න පළල ස්වයංක්‍රීය පරිමාණයකින් තොරව පරිමාණය කිරීම පමණි</string>
     <string name="overwrite">පවතින අයිතමය උඩින් ලියන්න</string>
     <string name="overwrite_info">ඔබ සතුව දැනටමත් ඇති ඕනෑම ගැළපෙන ගොනු ධාරක ගොනු මගින් නැවත ලියනු ලැබේ</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">ගීතයේ ඇති පද සංදර්ශන කරන්න</string>
     <string name="show_next_in_set">සෙට් එකේ ඊළඟ සින්දුව පෙන්වන්න</string>
     <string name="show_next_prev_in_song_menu">කට්ටලයක නැති ගීත සඳහා පෙර/ඊළඟ පෙන්වන්න (ගීත මෙනුව භාවිතයෙන්)</string>
+    <string name="show_next_line_preview">ඊළඟ පේළියේ පූර්ව දසුන පෙන්වන්න</string>
+    <string name="show_next_line_preview_hint">තිරයේ පතුලේ ඊළඟ කොටසේ පළමු පේළිය ප්‍රදර්ශනය කරන්න</string>
     <string name="show_prev_song">කට්ටලයේ පෙර ගීතය පෙන්වන්න</string>
     <string name="show_songs">ගීත පෙන්වන්න</string>
     <string name="show_tempo">මාතෘකාවේ tempo පෙන්වන්න</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Sila šou</string>
     <string name="override_scale_explanation">Ako je veličina fonta manja od minimalne željene veličine, da li želite da aplikacij koristi drugu metodu skaliranja? Korišćenje ove opcije Vas može primorati na skrolovanje pesme horizontalno i vertikalno</string>
     <string name="override_sticky">Premosti automatski prikaz lepljive beleške za ovu pesmu</string>
+    <string name="override_preview">Premosti prikaz pregleda sledeće linije za ovu pesmu</string>
     <string name="override_widthautoscale">Prebacivanje autozumiranja sa širine na mod bez autozumiranja</string>
     <string name="overwrite">Prepisati preko postojeće stavke</string>
     <string name="overwrite_info">Sve odgovarajuće datoteke koje već imate će biti prepisane od strane host fajlova</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Prikažite tekstove pronađene u pesmi</string>
     <string name="show_next_in_set">Prikaži sledeću pesmu u set listi</string>
     <string name="show_next_prev_in_song_menu">Takođe prikaži prethodnu/sledeću za pesme koje nisu u setu (pomoću menija pesama)</string>
+    <string name="show_next_line_preview">Прикажи преглед следеће линије</string>
+    <string name="show_next_line_preview_hint">Приказује прву линију следеће секције на дну екрана</string>
     <string name="show_prev_song">Prikaži prethodnu pesmu u setu</string>
     <string name="show_songs">Prikaži pesme</string>
     <string name="show_tempo">Pokažite tempo u naslovu</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Force show</string>
     <string name="override_scale_explanation">Om autoscale-teckensnittstorleken är mindre än önskad minsta teckensnittstorlek, vill du att appen ska åsidosättas till en annan skaleringsmetod? Användning av dessa alternativ kan tvinga dig att rulla horisontellt och vertikalt i en låt</string>
     <string name="override_sticky">Åsidosätt automatisk visning av klisterlappar för den här låten</string>
+    <string name="override_preview">Åsidosätt förhandsgranskning av nästa rad för den här låten</string>
     <string name="override_widthautoscale">Åsidosätt bredd endast skalning utan autoskala</string>
     <string name="overwrite">Skriv om befintligt objekt</string>
     <string name="overwrite_info">Alla matchande filer du redan har kommer att skrivas över av värdfilerna</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Visa text som finns i låten</string>
     <string name="show_next_in_set">Visa nästa låt i uppsättningen</string>
     <string name="show_next_prev_in_song_menu">Visa även föregående/nästa för låtar som inte finns i en uppsättning (med sångmenyn)</string>
+    <string name="show_next_line_preview">Visa förhandsgranskning av nästa rad</string>
+    <string name="show_next_line_preview_hint">Visa den första raden av nästa avsnitt längst ned på skärmen</string>
     <string name="show_prev_song">Visa föregående låt i set</string>
     <string name="show_songs">Visa låtar</string>
     <string name="show_tempo">Visa tempo i titeln</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">Шоу сили</string>
     <string name="override_scale_explanation">Якщо розмір шрифту Автомасштаб менше необхідного мінімального розміру шрифту, ви хочете, щоб додаток переобумовленої метод масштабування? Це може змусити вас прокручувати пісню по горизонталі і вертикалі.</string>
     <string name="override_sticky">Скасувати автоматичне відображення нотаток для цієї пісні</string>
+    <string name="override_preview">Скасувати відображення попереднього перегляду наступного рядка для цієї пісні</string>
     <string name="override_widthautoscale">Автомасштабування по ширині</string>
     <string name="overwrite">Переписати існуючий</string>
     <string name="overwrite_info">Будь-які відповідні файли, які у вас уже є, будуть перезаписані файлами хосту</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">Показати текст пісні</string>
     <string name="show_next_in_set">Показати наступну пісню в списку</string>
     <string name="show_next_prev_in_song_menu">Також показувати попередню/наступну для пісень, яких немає у наборі (за допомогою меню пісень)</string>
+    <string name="show_next_line_preview">Показати попередній перегляд наступного рядка</string>
+    <string name="show_next_line_preview_hint">Показати перший рядок наступного розділу внизу екрана</string>
     <string name="show_prev_song">Показати попередню пісню в наборі</string>
     <string name="show_songs">Показати пісні</string>
     <string name="show_tempo">Покажіть темп у заголовку</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -821,6 +821,7 @@
     <string name="override_on">力秀</string>
     <string name="override_scale_explanation">如果自动缩放字体大小小于所需的最小字体大小，你想该应用覆盖到不同的缩放方法？使用这些选项可能会迫使你在一首歌水平和垂直滚动。</string>
     <string name="override_sticky">覆盖这首歌曲的自动便签显示</string>
+    <string name="override_preview">覆盖此歌曲的下一行预览显示</string>
     <string name="override_widthautoscale">覆盖宽度仅扩展到不自动缩放</string>
     <string name="overwrite">覆盖现有项目</string>
     <string name="overwrite_info">您已有的任何匹配文件都将被主机文件覆盖</string>
@@ -1074,6 +1075,8 @@
     <string name="show_lyrics_info">显示歌曲中找到的歌词</string>
     <string name="show_next_in_set">在显示设置下一首歌曲</string>
     <string name="show_next_prev_in_song_menu">还显示不在集合中的歌曲的上一个/下一个（使用歌曲菜单）</string>
+    <string name="show_next_line_preview">显示下一行预览</string>
+    <string name="show_next_line_preview_hint">在屏幕底部显示下一部分的第一行</string>
     <string name="show_prev_song">显示集合中的上一首歌曲</string>
     <string name="show_songs">显示歌曲</string>
     <string name="show_tempo">在标题中显示节奏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1006,6 +1006,7 @@
     <string name="override_on">Force show</string>
     <string name="override_scale_explanation">If the autoscale font size is less than the desired minimum font size, do you want the app to override to a different scaling method?  Using these options may force you to scroll horizontally and vertically in a song</string>
     <string name="override_sticky">Override automatic sticky note display for this song</string>
+    <string name="override_preview">Override next line preview display for this song</string>
     <string name="override_widthautoscale">Override width only scaling to no autoscale</string>
     <string name="overwrite">Overwrite existing item</string>
     <string name="overwrite_info">Any matching files you already have will be overwritten by the host files</string>
@@ -1266,6 +1267,8 @@
     <string name="show_lyrics_info">Display lyrics found in the song</string>
     <string name="show_next_in_set">Show next song in set</string>
     <string name="show_next_prev_in_song_menu">Also show previous/next for songs not in a set (using song menu)</string>
+    <string name="show_next_line_preview">Show next line preview</string>
+    <string name="show_next_line_preview_hint">Display the first line of the next section at the bottom of the screen</string>
     <string name="show_prev_song">Show previous song in set</string>
     <string name="show_songs">Show songs</string>
     <string name="show_tempo">Show tempo in the title</string>


### PR DESCRIPTION
Adds a new preference in Settings > Displays > Connected Displays to show a preview of the first line from the next section at the bottom of the current slide. This helps congregation members anticipate upcoming lyrics when presentation operators are slow to advance slides.

Features:
- Toggle-able preference (default: off)
- Shows first lyric line from next section
- Semi-transparent (50% alpha) for visual distinction
- Matches current lyric styling (font, size, alignment)
- Automatically excludes headings, chords, and comments
- Works in Presenter and Stage modes only (not Performance mode)
- Excludes PDF, IMG, and image slide collections
- Add per-song override for next line preview display

Technical changes:
- Added showNextLinePreview preference to PresenterSettings
- Added three helper methods to SecondaryDisplay for preview logic
- Fixed font size to match actual lyrics (uses defFontSize)
- Fixed alignment with MATCH_PARENT layout params
- Added translations for all 17 supported languages
- Documented preference in Preferences.java