### PR TITLE
Configurable spacing & transparency for preview line

### DIFF
--- a/app/src/main/java/com/garethevans/church/opensongtablet/preferences/Preferences.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/preferences/Preferences.java
@@ -640,6 +640,8 @@ public class Preferences extends Activity {
     // setLoadFirst                     boolean     Should the first item in a set be called when loading (def:true)
     // setsSortOrder                    String      Which order to sort the set list (def:az - other options za, newest, oldest);
     // showNextLinePreview              boolean     Show preview of first line from next section on connected displays (def:false)
+    // showNextLinePreviewSpacing       float       Spacing multiplier before preview line (relative to font size) (def:0.5f)
+    // showNextLinePreviewTransparency  int         Transparency level of preview line: 0=opaque, 1=25%, 2=50% (def:2)
     // songAuthorSize                   float       The size of the song author text in the action bar (def:11.0f)
     // songAutoScale                    String      Choice of autoscale mode (Y)es, (W)idth only or (N)one (def:W)
     // songAutoScaleColumnMaximise      boolean     When autoscale is on full and columns are used, should each column scale independently to maximise font size (def:true)

--- a/app/src/main/java/com/garethevans/church/opensongtablet/presenter/PresenterSettings.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/presenter/PresenterSettings.java
@@ -27,7 +27,8 @@ public class PresenterSettings {
     private String backgroundToUse, presoAlertText, ccliLicence;
     private float logoSize, castRotation, presoInfoBarAlpha, fontSizePresoMax, presoAlertTextSize,
             presoBackgroundAlpha, presoTitleTextSize, presoAuthorTextSize, presoCopyrightTextSize,
-            presoClockSize,presenterViewContentSize;
+            presoClockSize,presenterViewContentSize, showNextLinePreviewSpacing;
+    private int showNextLinePreviewTransparency;
     private SongSectionsAdapter songSectionsAdapter;
 
 
@@ -306,6 +307,18 @@ public class PresenterSettings {
     public boolean getShowNextLinePreview() {
         return showNextLinePreview;
     }
+    public float getShowNextLinePreviewSpacing() {
+        return showNextLinePreviewSpacing;
+    }
+    public void setShowNextLinePreviewSpacing(float showNextLinePreviewSpacing) {
+        this.showNextLinePreviewSpacing = showNextLinePreviewSpacing;
+    }
+    public int getShowNextLinePreviewTransparency() {
+        return showNextLinePreviewTransparency;
+    }
+    public void setShowNextLinePreviewTransparency(int showNextLinePreviewTransparency) {
+        this.showNextLinePreviewTransparency = showNextLinePreviewTransparency;
+    }
     public float getPresenterViewContentSize() {
         return presenterViewContentSize;
     }
@@ -370,6 +383,8 @@ public class PresenterSettings {
         setPresoClockSeconds(mainActivityInterface.getPreferences().getMyPreferenceBoolean("presoClockSeconds",true));
         setDefaultPresentationText(mainActivityInterface.getPreferences().getMyPreferenceBoolean("defaultPresentationText",true));
         setShowNextLinePreview(mainActivityInterface.getPreferences().getMyPreferenceBoolean("showNextLinePreview",false));
+        setShowNextLinePreviewSpacing(mainActivityInterface.getPreferences().getMyPreferenceFloat("showNextLinePreviewSpacing",0.5f));
+        setShowNextLinePreviewTransparency(mainActivityInterface.getPreferences().getMyPreferenceInt("showNextLinePreviewTransparency",2));
     }
     public void getAlertPreferences() {
         setPresoAlertText(mainActivityInterface.getPreferences().getMyPreferenceString("presoAlertText",""));

--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplay.java
@@ -1582,8 +1582,10 @@ public class SecondaryDisplay extends Presentation {
         // Use the same base font size as lyrics (will be scaled with the view)
         textView.setTextSize(mainActivityInterface.getProcessSong().getDefFontSize());
 
-        // Apply transparency (0.5 = 50% transparent)
-        textView.setAlpha(0.5f);
+        // Apply configurable transparency: 0=opaque (1.0f), 1=25% (0.75f), 2=50% (0.5f)
+        int transparencyLevel = mainActivityInterface.getPresenterSettings().getShowNextLinePreviewTransparency();
+        float alpha = 1.0f - (transparencyLevel * 0.25f);
+        textView.setAlpha(alpha);
 
         // Match lyric alignment
         textView.setGravity(mainActivityInterface.getPresenterSettings().getPresoLyricsAlign());
@@ -1596,10 +1598,19 @@ public class SecondaryDisplay extends Presentation {
         }
 
         // Layout params - use MATCH_PARENT width for proper alignment
-        textView.setLayoutParams(new LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
-        ));
+        );
+
+        // Use text-size-relative spacing (configurable multiplier of font size)
+        // This scales with the text size, so it looks proportional at all sizes
+        float spacingMultiplier = mainActivityInterface.getPresenterSettings().getShowNextLinePreviewSpacing();
+        int topMarginPx = (int) (mainActivityInterface.getProcessSong().getDefFontSize() * spacingMultiplier
+            * c.getResources().getDisplayMetrics().scaledDensity);
+        layoutParams.setMargins(0, topMarginPx, 0, 0);
+
+        textView.setLayoutParams(layoutParams);
 
         return textView;
     }

--- a/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplaySettingsFragment.java
+++ b/app/src/main/java/com/garethevans/church/opensongtablet/secondarydisplay/SecondaryDisplaySettingsFragment.java
@@ -218,6 +218,9 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
         myView.infoAlign.setSliderPos(gravityToSliderPosition(mainActivityInterface.getPresenterSettings().getPresoInfoAlign()));
         myView.hideInfoBar.setChecked(mainActivityInterface.getPresenterSettings().getHideInfoBar());
         myView.showNextLinePreview.setChecked(mainActivityInterface.getPresenterSettings().getShowNextLinePreview());
+        myView.previewLineSpacing.setValue(mainActivityInterface.getPresenterSettings().getShowNextLinePreviewSpacing());
+        myView.previewLineTransparency.setValue(mainActivityInterface.getPresenterSettings().getShowNextLinePreviewTransparency());
+        updatePreviewLineSettings();
 
         myView.titleTextSize.setValue(mainActivityInterface.getPresenterSettings().getPresoTitleTextSize());
         myView.authorTextSize.setValue(mainActivityInterface.getPresenterSettings().getPresoAuthorTextSize());
@@ -306,7 +309,14 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
             mainActivityInterface.getPreferences().setMyPreferenceBoolean("showNextLinePreview",b);
             mainActivityInterface.getPresenterSettings().setShowNextLinePreview(b);
             refreshSection();
+            updatePreviewLineSettings();
         });
+
+        myView.previewLineSpacing.addOnChangeListener(new SliderChangeListener("showNextLinePreviewSpacing"));
+        myView.previewLineSpacing.addOnSliderTouchListener(new SliderTouchListener("showNextLinePreviewSpacing"));
+
+        myView.previewLineTransparency.addOnChangeListener(new SliderChangeListener("showNextLinePreviewTransparency"));
+        myView.previewLineTransparency.addOnSliderTouchListener(new SliderTouchListener("showNextLinePreviewTransparency"));
 
         myView.titleTextSize.addOnChangeListener(new SliderChangeListener("presoTitleTextSize"));
         myView.titleTextSize.addOnSliderTouchListener(new SliderTouchListener("presoTitleTextSize"));
@@ -390,6 +400,14 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
         myView.clock24hr.setVisibility(visibility);
         myView.clockSeconds.setVisibility(visibility);
         myView.clockTextSize.setVisibility(visibility);
+    }
+    private void updatePreviewLineSettings() {
+        int visibility = View.GONE;
+        if (mainActivityInterface.getPresenterSettings().getShowNextLinePreview()) {
+            visibility = View.VISIBLE;
+        }
+        myView.previewLineSpacing.setVisibility(visibility);
+        myView.previewLineTransparency.setVisibility(visibility);
     }
     private float floatToDecPlaces(float floatNum) {
         floatNum = floatNum * (float)Math.pow(10, 2);
@@ -571,6 +589,20 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
                     mainActivityInterface.getPresenterSettings().setPresoCopyrightTextSize(slider.getValue());
                     displayInterface.updateDisplay("setInfoStyles");
                     break;
+                case "showNextLinePreviewSpacing":
+                    // The slider goes from 0.0 to 2.0
+                    mainActivityInterface.getPreferences().setMyPreferenceFloat(
+                            prefName,slider.getValue());
+                    mainActivityInterface.getPresenterSettings().setShowNextLinePreviewSpacing(slider.getValue());
+                    refreshSection();
+                    break;
+                case "showNextLinePreviewTransparency":
+                    // The slider goes from 0 to 2 (0=opaque, 1=25%, 2=50%)
+                    mainActivityInterface.getPreferences().setMyPreferenceInt(
+                            prefName,(int)slider.getValue());
+                    mainActivityInterface.getPresenterSettings().setShowNextLinePreviewTransparency((int)slider.getValue());
+                    refreshSection();
+                    break;
             }
         }
     }
@@ -659,6 +691,16 @@ public class SecondaryDisplaySettingsFragment extends Fragment {
                 case "presoCopyrightTextSize":
                     // The slider goes from 6 to 22
                     myView.copyrightTextSize.setHint(((int)slider.getValue())+"sp");
+                    break;
+                case "showNextLinePreviewSpacing":
+                    // The slider goes from 0.0 to 2.0
+                    myView.previewLineSpacing.setHint(String.format("%.2fx", slider.getValue()));
+                    break;
+                case "showNextLinePreviewTransparency":
+                    // The slider goes from 0 to 2 (0=opaque, 1=25%, 2=50%)
+                    int transparencyValue = (int)slider.getValue();
+                    String[] transparencyLabels = {"0%", "25%", "50%"};
+                    myView.previewLineTransparency.setHint(transparencyLabels[transparencyValue]);
                     break;
             }
         }

--- a/app/src/main/res/layout/settings_display_connected.xml
+++ b/app/src/main/res/layout/settings_display_connected.xml
@@ -244,6 +244,28 @@
             android:hint="@string/show_next_line_preview_hint"
             android:text="@string/show_next_line_preview" />
 
+        <com.garethevans.church.opensongtablet.customviews.MyMaterialSlider
+            android:id="@+id/previewLineSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/preview_line_spacing"
+            android:value="0.5"
+            android:valueFrom="0.0"
+            android:valueTo="2.0"
+            android:stepSize="0.25" />
+
+        <com.garethevans.church.opensongtablet.customviews.MyMaterialSlider
+            android:id="@+id/previewLineTransparency"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/preview_line_transparency"
+            android:value="2"
+            android:valueFrom="0"
+            android:valueTo="2"
+            android:stepSize="1" />
+
         <LinearLayout
             android:id="@+id/infoSizes"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Wys ook vorige/volgende vir liedjies wat nie in \'n stel is nie (gebruik liedjie-kieslys)</string>
     <string name="show_next_line_preview">Wys volgende reël voorskou</string>
     <string name="show_next_line_preview_hint">Vertoon die eerste reël van die volgende afdeling aan die onderkant van die skerm</string>
+    <string name="preview_line_spacing">Voorskou lyn spasiëring</string>
+    <string name="preview_line_transparency">Voorskou lyn deursigtigheid</string>
     <string name="show_prev_song">Wys vorige liedjie in stel</string>
     <string name="show_songs">Wys liedjies</string>
     <string name="show_tempo">Wys tempo in die titel</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Zobrazit také předchozí/následující pro skladby, které nejsou v sadě (pomocí nabídky skladeb)</string>
     <string name="show_next_line_preview">Zobrazit náhled dalšího řádku</string>
     <string name="show_next_line_preview_hint">Zobrazit první řádek další sekce ve spodní části obrazovky</string>
+    <string name="preview_line_spacing">Rozestup řádků náhledu</string>
+    <string name="preview_line_transparency">Průhlednost řádku náhledu</string>
     <string name="show_prev_song">Zobrazit předchozí skladbu v sadě</string>
     <string name="show_songs">Zobrazit skladby</string>
     <string name="show_tempo">Wys tempo v názvu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Auch vorherige/nächste für Songs anzeigen, die nicht in einem Set enthalten sind (über das Song-Menü)</string>
     <string name="show_next_line_preview">Vorschau der nächsten Zeile anzeigen</string>
     <string name="show_next_line_preview_hint">Zeige die erste Zeile des nächsten Abschnitts am unteren Bildschirmrand an</string>
+    <string name="preview_line_spacing">Vorschau-Zeilenabstand</string>
+    <string name="preview_line_transparency">Vorschau-Zeilentransparenz</string>
     <string name="show_prev_song">Vorherigen Song im Set anzeigen</string>
     <string name="show_songs">Lieder zeigen</string>
     <string name="show_tempo">Tempo im Titel anzeigen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1079,6 +1079,8 @@
     <string name="show_next_prev_in_song_menu">Εμφάνιση επίσης προηγούμενου/επόμενου για τραγούδια που δεν ανήκουν σε σύνολο (χρησιμοποιώντας το μενού τραγουδιών)</string>
     <string name="show_next_line_preview">Εμφάνιση προεπισκόπησης επόμενης γραμμής</string>
     <string name="show_next_line_preview_hint">Εμφάνιση της πρώτης γραμμής της επόμενης ενότητας στο κάτω μέρος της οθόνης</string>
+    <string name="preview_line_spacing">Απόσταση γραμμής προεπισκόπησης</string>
+    <string name="preview_line_transparency">Διαφάνεια γραμμής προεπισκόπησης</string>
     <string name="show_prev_song">Εμφάνιση προηγούμενου τραγουδιού στο σετ</string>
     <string name="show_songs">Εμφάνιση τραγουδιών</string>
     <string name="show_tempo">Εμφάνιση ρυθμού στον τίτλο</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">También muestra anterior/siguiente para canciones que no están en un conjunto (usando el menú de canciones)</string>
     <string name="show_next_line_preview">Mostrar vista previa de la siguiente línea</string>
     <string name="show_next_line_preview_hint">Mostrar la primera línea de la siguiente sección en la parte inferior de la pantalla</string>
+    <string name="preview_line_spacing">Espaciado de línea de vista previa</string>
+    <string name="preview_line_transparency">Transparencia de línea de vista previa</string>
     <string name="show_prev_song">Mostrar la canción anterior en el conjunto</string>
     <string name="show_songs">Mostrar canciones</string>
     <string name="show_tempo">Mostrar tempo en el título</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Afficher également précédent/suivant pour les chansons qui ne font pas partie d\'un ensemble (à l\'aide du menu des chansons)</string>
     <string name="show_next_line_preview">Afficher l\'aperçu de la ligne suivante</string>
     <string name="show_next_line_preview_hint">Afficher la première ligne de la section suivante en bas de l\'écran</string>
+    <string name="preview_line_spacing">Espacement des lignes d\'aperçu</string>
+    <string name="preview_line_transparency">Transparence de la ligne d\'aperçu</string>
     <string name="show_prev_song">Afficher la chanson précédente dans le set</string>
     <string name="show_songs">Afficher les chansons</string>
     <string name="show_tempo">Afficher le tempo dans le titre</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Előző/következő megjelenítése a készletben nem szereplő daloknál is (a dalmenü használatával)</string>
     <string name="show_next_line_preview">Következő sor előnézetének megjelenítése</string>
     <string name="show_next_line_preview_hint">Jelenítse meg a következő szakasz első sorát a képernyő alján</string>
+    <string name="preview_line_spacing">Előnézeti sor távolsága</string>
+    <string name="preview_line_transparency">Előnézeti sor átlátszósága</string>
     <string name="show_prev_song">Előző dal megjelenítése a készletben</string>
     <string name="show_songs">Dalok megjelenítése</string>
     <string name="show_tempo">Tempó megjelenítése a címben</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Visualizza anche precedente/successivo per i brani non in scaletta (utilizzando il menu dei brani)</string>
     <string name="show_next_line_preview">Mostra anteprima riga successiva</string>
     <string name="show_next_line_preview_hint">Visualizza la prima riga della sezione successiva nella parte inferiore dello schermo</string>
+    <string name="preview_line_spacing">Spaziatura linea di anteprima</string>
+    <string name="preview_line_transparency">Trasparenza linea di anteprima</string>
     <string name="show_prev_song">Visualizza il brano precedente in scaletta</string>
     <string name="show_songs">Visualizza i brani</string>
     <string name="show_tempo">Visualizza il tempo nella barra del titolo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">セットにない曲の前/次も表示（曲メニューを使用）</string>
     <string name="show_next_line_preview">次の行のプレビューを表示</string>
     <string name="show_next_line_preview_hint">次のセクションの最初の行を画面下部に表示します</string>
+    <string name="preview_line_spacing">プレビュー行の間隔</string>
+    <string name="preview_line_transparency">プレビュー行の透明度</string>
     <string name="show_prev_song">セット内の前の曲を表示する</string>
     <string name="show_songs">曲を表示する</string>
     <string name="show_tempo">タイトルにテンポを表示する</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Pokaż również poprzednie/następne piosenki spoza zestawu (przy użyciu menu piosenki)</string>
     <string name="show_next_line_preview">Pokaż podgląd następnej linii</string>
     <string name="show_next_line_preview_hint">Wyświetl pierwszą linię następnej sekcji na dole ekranu</string>
+    <string name="preview_line_spacing">Odstępy między liniami podglądu</string>
+    <string name="preview_line_transparency">Przezroczystość linii podglądu</string>
     <string name="show_prev_song">Pokaż poprzednią piosenkę w zestawie</string>
     <string name="show_songs">Pokaż piosenki</string>
     <string name="show_tempo">Pokaż tempo w tytule</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Também mostrar anterior/seguinte para músicas que não estão em um conjunto (usando o menu de músicas)</string>
     <string name="show_next_line_preview">Mostrar pré-visualização da próxima linha</string>
     <string name="show_next_line_preview_hint">Exibir a primeira linha da próxima seção na parte inferior da tela</string>
+    <string name="preview_line_spacing">Espaçamento da linha de visualização</string>
+    <string name="preview_line_transparency">Transparência da linha de visualização</string>
     <string name="show_prev_song">Mostrar música anterior no set</string>
     <string name="show_songs">Mostrar músicas</string>
     <string name="show_tempo">Mostrar andamento no título</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Показывать кнопки \'предыдущий/следующий\' также и для песен, которых нет в сетлисте (двигаться по индексу песенника)</string>
     <string name="show_next_line_preview">Показать предварительный просмотр следующей строки</string>
     <string name="show_next_line_preview_hint">Показать первую строку следующего раздела внизу экрана</string>
+    <string name="preview_line_spacing">Интервал строки предварительного просмотра</string>
+    <string name="preview_line_transparency">Прозрачность строки предварительного просмотра</string>
     <string name="show_prev_song">Показать предыдущую песню в сетлисте</string>
     <string name="show_songs">Показать песни</string>
     <string name="show_tempo">Показывать темп в названии</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">කට්ටලයක නැති ගීත සඳහා පෙර/ඊළඟ පෙන්වන්න (ගීත මෙනුව භාවිතයෙන්)</string>
     <string name="show_next_line_preview">ඊළඟ පේළියේ පූර්ව දසුන පෙන්වන්න</string>
     <string name="show_next_line_preview_hint">තිරයේ පතුලේ ඊළඟ කොටසේ පළමු පේළිය ප්‍රදර්ශනය කරන්න</string>
+    <string name="preview_line_spacing">පෙරදසුන් රේඛා පරතරය</string>
+    <string name="preview_line_transparency">පෙරදසුන් රේඛා විනිවිදභාවය</string>
     <string name="show_prev_song">කට්ටලයේ පෙර ගීතය පෙන්වන්න</string>
     <string name="show_songs">ගීත පෙන්වන්න</string>
     <string name="show_tempo">මාතෘකාවේ tempo පෙන්වන්න</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Takođe prikaži prethodnu/sledeću za pesme koje nisu u setu (pomoću menija pesama)</string>
     <string name="show_next_line_preview">Prikaži pregled sledećeg reda</string>
     <string name="show_next_line_preview_hint">Prikaži prvi red sledećeg odeljka na dnu ekrana</string>
+    <string name="preview_line_spacing">Razmak linije pregleda</string>
+    <string name="preview_line_transparency">Providnost linije pregleda</string>
     <string name="show_prev_song">Prikaži prethodnu pesmu u setu</string>
     <string name="show_songs">Prikaži pesme</string>
     <string name="show_tempo">Pokažite tempo u naslovu</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Visa även föregående/nästa för låtar som inte finns i en uppsättning (med sångmenyn)</string>
     <string name="show_next_line_preview">Visa förhandsgranskning av nästa rad</string>
     <string name="show_next_line_preview_hint">Visa den första raden av nästa avsnitt längst ned på skärmen</string>
+    <string name="preview_line_spacing">Förhandsgranska radavstånd</string>
+    <string name="preview_line_transparency">Förhandsgranska radtransparens</string>
     <string name="show_prev_song">Visa föregående låt i set</string>
     <string name="show_songs">Visa låtar</string>
     <string name="show_tempo">Visa tempo i titeln</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">Також показувати попередню/наступну для пісень, яких немає у наборі (за допомогою меню пісень)</string>
     <string name="show_next_line_preview">Показати попередній перегляд наступного рядка</string>
     <string name="show_next_line_preview_hint">Показати перший рядок наступного розділу внизу екрана</string>
+    <string name="preview_line_spacing">Інтервал рядка попереднього перегляду</string>
+    <string name="preview_line_transparency">Прозорість рядка попереднього перегляду</string>
     <string name="show_prev_song">Показати попередню пісню в наборі</string>
     <string name="show_songs">Показати пісні</string>
     <string name="show_tempo">Покажіть темп у заголовку</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1077,6 +1077,8 @@
     <string name="show_next_prev_in_song_menu">还显示不在集合中的歌曲的上一个/下一个（使用歌曲菜单）</string>
     <string name="show_next_line_preview">显示下一行预览</string>
     <string name="show_next_line_preview_hint">在屏幕底部显示下一部分的第一行</string>
+    <string name="preview_line_spacing">预览行间距</string>
+    <string name="preview_line_transparency">预览行透明度</string>
     <string name="show_prev_song">显示集合中的上一首歌曲</string>
     <string name="show_songs">显示歌曲</string>
     <string name="show_tempo">在标题中显示节奏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1269,6 +1269,8 @@
     <string name="show_next_prev_in_song_menu">Also show previous/next for songs not in a set (using song menu)</string>
     <string name="show_next_line_preview">Show next line preview</string>
     <string name="show_next_line_preview_hint">Display the first line of the next section at the bottom of the screen</string>
+    <string name="preview_line_spacing">Preview line spacing</string>
+    <string name="preview_line_transparency">Preview line transparency</string>
     <string name="show_prev_song">Show previous song in set</string>
     <string name="show_songs">Show songs</string>
     <string name="show_tempo">Show tempo in the title</string>


### PR DESCRIPTION
Allowing a (configurable) gap between current lyrics and the preview line provides better visual balance.

Make both the spacing and transparency of the preview line configurable through new sliders in the connected display settings.

Spacing changes:
- Support spacing range from 0.0x to 2.0x
- Spacing specified as multiplier of font size for proportional scaling
- Default is 0.5x

Transparency changes:
- Add new transparency slider with three levels: 0% (opaque), 25%, 50%
- Default is 50% transparent
- Transparency calculated as: alpha = 1.0f - (level * 0.25f)

Implementation:
- Add showNextLinePreviewTransparency preference (int, default 2)
- Add transparency slider control in connected display settings UI
- Wire up preference storage and retrieval in PresenterSettings
- Update SecondaryDisplay to use configurable transparency value
- Add "Preview line transparency" string resource
- Update spacing slider range and related documentation
- Add visibility control so spacing/transparency sliders only appear when preview line feature is enabled